### PR TITLE
mem-cache: Implement Fetch Directed Prefetcher

### DIFF
--- a/configs/example/fetch_directed_prefetcher.py
+++ b/configs/example/fetch_directed_prefetcher.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 All-Hands
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This script demonstrates the use of the Fetch Directed Prefetcher.
+It configures a system with an O3 CPU and L1/L2 caches, with the
+L2 cache using the Fetch Directed Prefetcher.
+"""
+
+import argparse
+import sys
+
+import m5
+from m5.objects import *
+from m5.util import addToPath
+
+addToPath('../')
+
+from common import Options
+from common import Simulation
+from common import CacheConfig
+from common import MemConfig
+from common.Caches import *
+
+def main():
+    parser = argparse.ArgumentParser()
+    Options.addCommonOptions(parser)
+    Options.addSEOptions(parser)
+    
+    # Fetch Directed Prefetcher specific options
+    parser.add_argument("--piq-size", type=int, default=16,
+                      help="Size of the Prefetch Instruction Queue")
+    parser.add_argument("--ftq-size", type=int, default=16,
+                      help="Size of the Fetch Target Queue")
+    parser.add_argument("--prefetch-buffer-size", type=int, default=32,
+                      help="Size of the prefetch buffer")
+    parser.add_argument("--prefetch-degree", type=int, default=4,
+                      help="Number of prefetches to issue per cycle")
+    parser.add_argument("--prefetch-distance", type=int, default=2,
+                      help="Prefetch distance in blocks")
+    
+    args = parser.parse_args()
+
+    # Create the system
+    system = System(cpu = [DerivO3CPU(cpu_id=0)],
+                    mem_mode = 'timing',
+                    mem_ranges = [AddrRange('512MB')],
+                    cache_line_size = 64)
+
+    # Create a process
+    process = Process()
+    process.cmd = [args.cmd] + args.options.split()
+    system.cpu[0].workload = process
+    system.cpu[0].createThreads()
+
+    # Set up the system's memory system
+    system.membus = SystemXBar()
+    system.system_port = system.membus.cpu_side_ports
+    CacheConfig.config_cache(args, system)
+    MemConfig.config_mem(args, system)
+    
+    # Configure the L2 cache to use the Fetch Directed Prefetcher
+    system.l2 = L2Cache(size='1MB', assoc=8)
+    system.l2.prefetcher = FetchDirectedPrefetcher(
+        piq_size=args.piq_size,
+        ftq_size=args.ftq_size,
+        prefetch_buffer_size=args.prefetch_buffer_size,
+        prefetch_degree=args.prefetch_degree,
+        prefetch_distance=args.prefetch_distance
+    )
+    
+    # Connect the L2 cache to the memory bus
+    system.l2.cpu_side = system.l1toL2bus.mem_side_ports
+    system.l2.mem_side = system.membus.cpu_side_ports
+
+    # Set up the root SimObject and start the simulation
+    root = Root(full_system = False, system = system)
+    
+    # Instantiate the system
+    m5.instantiate()
+
+    # Run the simulation
+    print("Beginning simulation!")
+    exit_event = m5.simulate()
+    print('Exiting @ tick {} because {}'
+          .format(m5.curTick(), exit_event.getCause()))
+
+if __name__ == "__m5_main__":
+    main()

--- a/configs/example/fetch_directed_test.py
+++ b/configs/example/fetch_directed_test.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 All-Hands
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This script tests specific features of the Fetch Directed Prefetcher:
+1. Decoupled branch predictor and instruction cache
+2. Marking fetch blocks kicked out of the instruction cache
+3. Using idle instruction cache ports to filter prefetch requests
+
+It runs a series of tests with different configurations to isolate and
+measure the impact of each feature.
+"""
+
+import argparse
+import csv
+import os
+import sys
+
+import m5
+from m5.objects import *
+from m5.stats import periodicStatDump
+from m5.util import addToPath
+
+addToPath('../')
+
+from common import Options
+from common import Simulation
+from common import CacheConfig
+from common import MemConfig
+from common.Caches import *
+
+def create_cpu_and_system(args, test_config):
+    """Create a system with the specified test configuration"""
+    
+    # Create the system
+    system = System(cpu = [DerivO3CPU(cpu_id=0)],
+                    mem_mode = 'timing',
+                    mem_ranges = [AddrRange('512MB')],
+                    cache_line_size = 64)
+
+    # Create a process
+    process = Process()
+    process.cmd = [args.cmd] + args.options.split()
+    system.cpu[0].workload = process
+    system.cpu[0].createThreads()
+
+    # Set up the system's memory system
+    system.membus = SystemXBar()
+    system.system_port = system.membus.cpu_side_ports
+    
+    # Create caches
+    system.l1i = L1ICache(size=args.l1i_size)
+    system.l1d = L1DCache(size=args.l1d_size)
+    system.l2 = L2Cache(size=args.l2_size, assoc=args.l2_assoc)
+    system.l1toL2bus = L2XBar()
+    
+    # Connect the L1 caches to the CPU
+    system.cpu[0].icache_port = system.l1i.cpu_side
+    system.cpu[0].dcache_port = system.l1d.cpu_side
+    
+    # Connect the L1 caches to the L2 bus
+    system.l1i.mem_side = system.l1toL2bus.cpu_side_ports
+    system.l1d.mem_side = system.l1toL2bus.cpu_side_ports
+    
+    # Configure the Fetch Directed Prefetcher with specific test settings
+    system.l2.prefetcher = FetchDirectedPrefetcher(
+        piq_size=args.piq_size,
+        ftq_size=args.ftq_size,
+        prefetch_buffer_size=args.prefetch_buffer_size,
+        prefetch_degree=args.prefetch_degree,
+        prefetch_distance=args.prefetch_distance,
+        # Test-specific configuration parameters
+        enable_decoupled_bp=test_config.get("enable_decoupled_bp", True),
+        enable_cache_eviction_tracking=test_config.get("enable_cache_eviction_tracking", True),
+        enable_idle_port_filtering=test_config.get("enable_idle_port_filtering", True)
+    )
+    
+    # Connect the L2 cache to the memory bus
+    system.l2.cpu_side = system.l1toL2bus.mem_side_ports
+    system.l2.mem_side = system.membus.cpu_side_ports
+    
+    # Setup the memory system
+    MemConfig.config_mem(args, system)
+    
+    return system
+
+def run_test(args, test_config):
+    """Run a test with the specified configuration and return stats"""
+    
+    # Create the system with the specified test configuration
+    system = create_cpu_and_system(args, test_config)
+    
+    # Set up the root SimObject and start the simulation
+    root = Root(full_system = False, system = system)
+    
+    # Instantiate the system
+    m5.instantiate()
+    
+    # Setup periodic stat dump
+    periodicStatDump(args.stat_period)
+    
+    # Run the simulation
+    print(f"Beginning simulation with test configuration: {test_config['name']}")
+    exit_event = m5.simulate(args.max_insts)
+    print(f'Exiting @ tick {m5.curTick()} because {exit_event.getCause()}')
+    
+    # Collect stats
+    stats = {}
+    stats['test_name'] = test_config['name']
+    stats['sim_ticks'] = m5.curTick()
+    stats['sim_seconds'] = m5.curTick() / 1e12
+    stats['ipc'] = system.cpu[0].ipc.value
+    stats['icache_miss_rate'] = system.l1i.overall_miss_rate.value
+    stats['l2_miss_rate'] = system.l2.overall_miss_rate.value
+    stats['pf_candidates_identified'] = system.l2.prefetcher.pfCandidatesIdentified.value
+    stats['pf_candidates_filtered'] = system.l2.prefetcher.pfCandidatesFiltered.value
+    stats['pf_issued_to_l2'] = system.l2.prefetcher.pfIssuedToL2.value
+    stats['pf_buffer_hits'] = system.l2.prefetcher.pfBufferHits.value
+    
+    return stats
+
+def main():
+    parser = argparse.ArgumentParser()
+    Options.addCommonOptions(parser)
+    Options.addSEOptions(parser)
+    
+    # Cache configuration options
+    parser.add_argument("--l1i-size", type=str, default="32kB",
+                      help="L1 instruction cache size")
+    parser.add_argument("--l1d-size", type=str, default="32kB",
+                      help="L1 data cache size")
+    parser.add_argument("--l2-size", type=str, default="1MB",
+                      help="L2 cache size")
+    parser.add_argument("--l2-assoc", type=int, default=8,
+                      help="L2 cache associativity")
+    
+    # Simulation options
+    parser.add_argument("--max-insts", type=int, default=100000000,
+                      help="Maximum number of instructions to simulate")
+    parser.add_argument("--stat-period", type=int, default=10000000,
+                      help="Period in ticks to dump statistics")
+    
+    # Fetch Directed Prefetcher specific options
+    parser.add_argument("--piq-size", type=int, default=16,
+                      help="Size of the Prefetch Instruction Queue")
+    parser.add_argument("--ftq-size", type=int, default=16,
+                      help="Size of the Fetch Target Queue")
+    parser.add_argument("--prefetch-buffer-size", type=int, default=32,
+                      help="Size of the prefetch buffer")
+    parser.add_argument("--prefetch-degree", type=int, default=4,
+                      help="Number of prefetches to issue per cycle")
+    parser.add_argument("--prefetch-distance", type=int, default=2,
+                      help="Prefetch distance in blocks")
+    
+    # Output options
+    parser.add_argument("--output-dir", type=str, default="fetch_directed_test_results",
+                      help="Directory to store results")
+    
+    args = parser.parse_args()
+    
+    # Create output directory if it doesn't exist
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+    
+    # Define test configurations to isolate and measure each feature
+    test_configs = [
+        {
+            "name": "baseline_no_prefetching",
+            "enable_decoupled_bp": False,
+            "enable_cache_eviction_tracking": False,
+            "enable_idle_port_filtering": False
+        },
+        {
+            "name": "decoupled_bp_only",
+            "enable_decoupled_bp": True,
+            "enable_cache_eviction_tracking": False,
+            "enable_idle_port_filtering": False
+        },
+        {
+            "name": "eviction_tracking_only",
+            "enable_decoupled_bp": False,
+            "enable_cache_eviction_tracking": True,
+            "enable_idle_port_filtering": False
+        },
+        {
+            "name": "idle_port_filtering_only",
+            "enable_decoupled_bp": False,
+            "enable_cache_eviction_tracking": False,
+            "enable_idle_port_filtering": True
+        },
+        {
+            "name": "decoupled_bp_and_eviction_tracking",
+            "enable_decoupled_bp": True,
+            "enable_cache_eviction_tracking": True,
+            "enable_idle_port_filtering": False
+        },
+        {
+            "name": "decoupled_bp_and_idle_port_filtering",
+            "enable_decoupled_bp": True,
+            "enable_cache_eviction_tracking": False,
+            "enable_idle_port_filtering": True
+        },
+        {
+            "name": "eviction_tracking_and_idle_port_filtering",
+            "enable_decoupled_bp": False,
+            "enable_cache_eviction_tracking": True,
+            "enable_idle_port_filtering": True
+        },
+        {
+            "name": "full_fetch_directed_prefetching",
+            "enable_decoupled_bp": True,
+            "enable_cache_eviction_tracking": True,
+            "enable_idle_port_filtering": True
+        }
+    ]
+    
+    # Run tests for each configuration
+    results = []
+    for config in test_configs:
+        # Reset the simulation
+        m5.reset()
+        
+        # Run the test with the current configuration
+        stats = run_test(args, config)
+        results.append(stats)
+    
+    # Write results to CSV
+    csv_file = os.path.join(args.output_dir, "fetch_directed_test_results.csv")
+    with open(csv_file, 'w', newline='') as f:
+        fieldnames = ['test_name', 'sim_ticks', 'sim_seconds', 'ipc', 
+                     'icache_miss_rate', 'l2_miss_rate', 
+                     'pf_candidates_identified', 'pf_candidates_filtered', 
+                     'pf_issued_to_l2', 'pf_buffer_hits']
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for result in results:
+            writer.writerow(result)
+    
+    # Print summary
+    print("\nFetch Directed Prefetcher Feature Test Summary:")
+    print("=" * 100)
+    print(f"{'Test Configuration':<40} {'IPC':<10} {'I$ Miss Rate':<15} {'L2 Miss Rate':<15} {'PF Buffer Hits':<15}")
+    print("-" * 100)
+    for result in results:
+        print(f"{result['test_name']:<40} {result['ipc']:<10.4f} {result['icache_miss_rate']:<15.4f} {result['l2_miss_rate']:<15.4f} {result['pf_buffer_hits']:<15.0f}")
+    print("=" * 100)
+    print(f"Detailed results saved to {csv_file}")
+
+if __name__ == "__m5_main__":
+    main()

--- a/configs/example/prefetcher_comparison.py
+++ b/configs/example/prefetcher_comparison.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 All-Hands
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This script compares the performance of different instruction prefetchers:
+1. No prefetching (baseline)
+2. Next-line prefetching
+3. Streaming buffer prefetching
+4. Fetch Directed Prefetching
+
+It runs the same benchmark with each prefetcher and reports performance metrics.
+"""
+
+import argparse
+import csv
+import os
+import sys
+
+import m5
+from m5.objects import *
+from m5.stats import periodicStatDump
+from m5.util import addToPath
+
+addToPath('../')
+
+from common import Options
+from common import Simulation
+from common import CacheConfig
+from common import MemConfig
+from common.Caches import *
+
+def create_cpu_and_system(args, prefetcher_type=None, prefetcher_params=None):
+    """Create a system with the specified prefetcher"""
+    
+    # Create the system
+    system = System(cpu = [DerivO3CPU(cpu_id=0)],
+                    mem_mode = 'timing',
+                    mem_ranges = [AddrRange('512MB')],
+                    cache_line_size = 64)
+
+    # Create a process
+    process = Process()
+    process.cmd = [args.cmd] + args.options.split()
+    system.cpu[0].workload = process
+    system.cpu[0].createThreads()
+
+    # Set up the system's memory system
+    system.membus = SystemXBar()
+    system.system_port = system.membus.cpu_side_ports
+    
+    # Create caches
+    system.l1i = L1ICache(size=args.l1i_size)
+    system.l1d = L1DCache(size=args.l1d_size)
+    system.l2 = L2Cache(size=args.l2_size, assoc=args.l2_assoc)
+    system.l1toL2bus = L2XBar()
+    
+    # Connect the L1 caches to the CPU
+    system.cpu[0].icache_port = system.l1i.cpu_side
+    system.cpu[0].dcache_port = system.l1d.cpu_side
+    
+    # Connect the L1 caches to the L2 bus
+    system.l1i.mem_side = system.l1toL2bus.cpu_side_ports
+    system.l1d.mem_side = system.l1toL2bus.cpu_side_ports
+    
+    # Configure the prefetcher based on the type
+    if prefetcher_type:
+        if prefetcher_type == "NextLinePrefetcher":
+            system.l2.prefetcher = StridePrefetcher(
+                degree=1,
+                latency=1,
+                queue_size=32,
+                queue_squash=True,
+                queue_filter=True,
+                queue_size_opt="true",
+                queue_filter_opt="true",
+                tag_prefetch="false",
+                use_master_id="true"
+            )
+        elif prefetcher_type == "StreamingBufferPrefetcher":
+            system.l2.prefetcher = StreamPrefetcher(
+                degree=4,
+                distance=16,
+                latency=1,
+                queue_size=32,
+                queue_squash=True,
+                queue_filter=True,
+                queue_size_opt="true",
+                queue_filter_opt="true",
+                tag_prefetch="false",
+                use_master_id="true"
+            )
+        elif prefetcher_type == "FetchDirectedPrefetcher":
+            system.l2.prefetcher = FetchDirectedPrefetcher(
+                piq_size=prefetcher_params.get("piq_size", 16),
+                ftq_size=prefetcher_params.get("ftq_size", 16),
+                prefetch_buffer_size=prefetcher_params.get("prefetch_buffer_size", 32),
+                prefetch_degree=prefetcher_params.get("prefetch_degree", 4),
+                prefetch_distance=prefetcher_params.get("prefetch_distance", 2)
+            )
+    
+    # Connect the L2 cache to the memory bus
+    system.l2.cpu_side = system.l1toL2bus.mem_side_ports
+    system.l2.mem_side = system.membus.cpu_side_ports
+    
+    # Setup the memory system
+    MemConfig.config_mem(args, system)
+    
+    return system
+
+def run_simulation(args, prefetcher_type=None, prefetcher_params=None):
+    """Run a simulation with the specified prefetcher and return stats"""
+    
+    # Create the system with the specified prefetcher
+    system = create_cpu_and_system(args, prefetcher_type, prefetcher_params)
+    
+    # Set up the root SimObject and start the simulation
+    root = Root(full_system = False, system = system)
+    
+    # Instantiate the system
+    m5.instantiate()
+    
+    # Setup periodic stat dump
+    periodicStatDump(args.stat_period)
+    
+    # Run the simulation
+    print(f"Beginning simulation with prefetcher: {prefetcher_type if prefetcher_type else 'None'}")
+    exit_event = m5.simulate(args.max_insts)
+    print(f'Exiting @ tick {m5.curTick()} because {exit_event.getCause()}')
+    
+    # Collect stats
+    stats = {}
+    stats['prefetcher'] = prefetcher_type if prefetcher_type else 'None'
+    stats['sim_ticks'] = m5.curTick()
+    stats['sim_seconds'] = m5.curTick() / 1e12
+    stats['ipc'] = system.cpu[0].ipc.value
+    stats['icache_miss_rate'] = system.l1i.overall_miss_rate.value
+    stats['l2_miss_rate'] = system.l2.overall_miss_rate.value
+    
+    if prefetcher_type == "FetchDirectedPrefetcher":
+        stats['pf_candidates_identified'] = system.l2.prefetcher.pfCandidatesIdentified.value
+        stats['pf_candidates_filtered'] = system.l2.prefetcher.pfCandidatesFiltered.value
+        stats['pf_issued_to_l2'] = system.l2.prefetcher.pfIssuedToL2.value
+        stats['pf_buffer_hits'] = system.l2.prefetcher.pfBufferHits.value
+    
+    return stats
+
+def main():
+    parser = argparse.ArgumentParser()
+    Options.addCommonOptions(parser)
+    Options.addSEOptions(parser)
+    
+    # Cache configuration options
+    parser.add_argument("--l1i-size", type=str, default="32kB",
+                      help="L1 instruction cache size")
+    parser.add_argument("--l1d-size", type=str, default="32kB",
+                      help="L1 data cache size")
+    parser.add_argument("--l2-size", type=str, default="1MB",
+                      help="L2 cache size")
+    parser.add_argument("--l2-assoc", type=int, default=8,
+                      help="L2 cache associativity")
+    
+    # Simulation options
+    parser.add_argument("--max-insts", type=int, default=100000000,
+                      help="Maximum number of instructions to simulate")
+    parser.add_argument("--stat-period", type=int, default=10000000,
+                      help="Period in ticks to dump statistics")
+    
+    # Fetch Directed Prefetcher specific options
+    parser.add_argument("--piq-size", type=int, default=16,
+                      help="Size of the Prefetch Instruction Queue")
+    parser.add_argument("--ftq-size", type=int, default=16,
+                      help="Size of the Fetch Target Queue")
+    parser.add_argument("--prefetch-buffer-size", type=int, default=32,
+                      help="Size of the prefetch buffer")
+    parser.add_argument("--prefetch-degree", type=int, default=4,
+                      help="Number of prefetches to issue per cycle")
+    parser.add_argument("--prefetch-distance", type=int, default=2,
+                      help="Prefetch distance in blocks")
+    
+    # Output options
+    parser.add_argument("--output-dir", type=str, default="prefetcher_comparison_results",
+                      help="Directory to store results")
+    
+    args = parser.parse_args()
+    
+    # Create output directory if it doesn't exist
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+    
+    # Prefetcher configurations to test
+    prefetcher_configs = [
+        {"type": None, "params": {}},  # No prefetching (baseline)
+        {"type": "NextLinePrefetcher", "params": {}},  # Next-line prefetching
+        {"type": "StreamingBufferPrefetcher", "params": {}},  # Streaming buffer prefetching
+        {"type": "FetchDirectedPrefetcher", "params": {  # Fetch Directed Prefetching
+            "piq_size": args.piq_size,
+            "ftq_size": args.ftq_size,
+            "prefetch_buffer_size": args.prefetch_buffer_size,
+            "prefetch_degree": args.prefetch_degree,
+            "prefetch_distance": args.prefetch_distance
+        }}
+    ]
+    
+    # Run simulations for each prefetcher configuration
+    results = []
+    for config in prefetcher_configs:
+        # Reset the simulation
+        m5.reset()
+        
+        # Run the simulation with the current prefetcher
+        stats = run_simulation(args, config["type"], config["params"])
+        results.append(stats)
+    
+    # Write results to CSV
+    csv_file = os.path.join(args.output_dir, "prefetcher_comparison.csv")
+    with open(csv_file, 'w', newline='') as f:
+        fieldnames = ['prefetcher', 'sim_ticks', 'sim_seconds', 'ipc', 
+                     'icache_miss_rate', 'l2_miss_rate', 
+                     'pf_candidates_identified', 'pf_candidates_filtered', 
+                     'pf_issued_to_l2', 'pf_buffer_hits']
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for result in results:
+            writer.writerow(result)
+    
+    # Print summary
+    print("\nPrefetcher Comparison Summary:")
+    print("=" * 80)
+    print(f"{'Prefetcher':<25} {'IPC':<10} {'I$ Miss Rate':<15} {'L2 Miss Rate':<15}")
+    print("-" * 80)
+    for result in results:
+        print(f"{result['prefetcher']:<25} {result['ipc']:<10.4f} {result['icache_miss_rate']:<15.4f} {result['l2_miss_rate']:<15.4f}")
+    print("=" * 80)
+    print(f"Detailed results saved to {csv_file}")
+
+if __name__ == "__m5_main__":
+    main()

--- a/configs/example/run_prefetcher_comparison.sh
+++ b/configs/example/run_prefetcher_comparison.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Copyright (c) 2025 All-Hands
+# All rights reserved.
+#
+# This script runs the prefetcher comparison tests with different benchmarks
+
+# Set the base directory for results
+RESULTS_DIR="prefetcher_comparison_results"
+mkdir -p $RESULTS_DIR
+
+# SPEC CPU benchmarks to test (assuming they are installed)
+BENCHMARKS=(
+    "/bin/ls"  # Simple command for testing
+    "/bin/grep"  # Another simple command for testing
+)
+
+# Command line arguments for each benchmark
+BENCHMARK_ARGS=(
+    "-la /"
+    "-r \"test\" /etc"
+)
+
+# Run the comparison for each benchmark
+for i in "${!BENCHMARKS[@]}"; do
+    BENCHMARK=${BENCHMARKS[$i]}
+    ARGS=${BENCHMARK_ARGS[$i]}
+    BENCHMARK_NAME=$(basename $BENCHMARK)
+    
+    echo "Running prefetcher comparison for $BENCHMARK_NAME..."
+    
+    # Create a directory for this benchmark's results
+    BENCHMARK_DIR="$RESULTS_DIR/$BENCHMARK_NAME"
+    mkdir -p $BENCHMARK_DIR
+    
+    # Run the comparison script
+    ./build/X86/gem5.opt configs/example/prefetcher_comparison.py \
+        --cmd=$BENCHMARK \
+        --options="$ARGS" \
+        --output-dir=$BENCHMARK_DIR \
+        --max-insts=10000000 \
+        --stat-period=1000000 \
+        --l1i-size=32kB \
+        --l1d-size=32kB \
+        --l2-size=1MB \
+        --l2-assoc=8 \
+        --piq-size=16 \
+        --ftq-size=16 \
+        --prefetch-buffer-size=32 \
+        --prefetch-degree=4 \
+        --prefetch-distance=2
+    
+    echo "Completed prefetcher comparison for $BENCHMARK_NAME"
+    echo "Results saved to $BENCHMARK_DIR"
+    echo ""
+done
+
+# Generate a summary report
+echo "Generating summary report..."
+SUMMARY_FILE="$RESULTS_DIR/summary.txt"
+
+echo "Prefetcher Comparison Summary" > $SUMMARY_FILE
+echo "============================" >> $SUMMARY_FILE
+echo "" >> $SUMMARY_FILE
+
+for i in "${!BENCHMARKS[@]}"; do
+    BENCHMARK_NAME=$(basename ${BENCHMARKS[$i]})
+    BENCHMARK_DIR="$RESULTS_DIR/$BENCHMARK_NAME"
+    CSV_FILE="$BENCHMARK_DIR/prefetcher_comparison.csv"
+    
+    if [ -f "$CSV_FILE" ]; then
+        echo "Results for $BENCHMARK_NAME:" >> $SUMMARY_FILE
+        echo "------------------------" >> $SUMMARY_FILE
+        
+        # Extract and format the data from the CSV file
+        echo "Prefetcher | IPC | I$ Miss Rate | L2 Miss Rate" >> $SUMMARY_FILE
+        echo "----------|-----|--------------|-------------" >> $SUMMARY_FILE
+        
+        # Skip the header line and process each row
+        tail -n +2 $CSV_FILE | while IFS=, read -r prefetcher sim_ticks sim_seconds ipc icache_miss_rate l2_miss_rate rest; do
+            echo "$prefetcher | $ipc | $icache_miss_rate | $l2_miss_rate" >> $SUMMARY_FILE
+        done
+        
+        echo "" >> $SUMMARY_FILE
+    fi
+done
+
+echo "Summary report generated at $SUMMARY_FILE"
+echo "Prefetcher comparison tests completed!"

--- a/src/mem/cache/SConscript
+++ b/src/mem/cache/SConscript
@@ -62,10 +62,11 @@ DebugFlag('HWPrefetch')
 DebugFlag('MSHR')
 DebugFlag('HWPrefetchQueue')
 DebugFlag('PartitionPolicy')
+DebugFlag('FetchDirectedPrefetch')
 
 # CacheTags is so outrageously verbose, printing the cache's entire tag
 # array on each timing access, that you should probably have to ask for
 # it explicitly even above and beyond CacheAll.
 CompoundFlag('CacheAll', ['Cache', 'CacheComp', 'CachePort', 'CacheRepl',
                           'CacheVerbose', 'HWPrefetch', 'MSHR',
-                          'PartitionPolicy'])
+                          'PartitionPolicy', 'FetchDirectedPrefetch'])

--- a/src/mem/cache/prefetch/FetchDirectedPrefetcher.py
+++ b/src/mem/cache/prefetch/FetchDirectedPrefetcher.py
@@ -48,3 +48,12 @@ class FetchDirectedPrefetcher(QueuedPrefetcher):
     
     # Prefetch distance in blocks
     prefetch_distance = Param.Unsigned(2, "Prefetch distance in blocks")
+    
+    # Enable/disable decoupled branch predictor
+    enable_decoupled_bp = Param.Bool(True, "Enable decoupled branch predictor")
+    
+    # Enable/disable cache eviction tracking
+    enable_cache_eviction_tracking = Param.Bool(True, "Enable tracking of blocks kicked out of the instruction cache")
+    
+    # Enable/disable idle port filtering
+    enable_idle_port_filtering = Param.Bool(True, "Enable using idle instruction cache ports to filter prefetch requests")

--- a/src/mem/cache/prefetch/FetchDirectedPrefetcher.py
+++ b/src/mem/cache/prefetch/FetchDirectedPrefetcher.py
@@ -1,6 +1,4 @@
-# -*- mode:python -*-
-
-# Copyright (c) 2006 The Regents of The University of Michigan
+# Copyright (c) 2025 All-Hands
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,35 +24,27 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Import('*')
+from m5.params import *
+from m5.proxy import *
 
-SimObject('Prefetcher.py', sim_objects=[
-    'BasePrefetcher', 'MultiPrefetcher', 'QueuedPrefetcher',
-    'StridePrefetcherHashedSetAssociative', 'StridePrefetcher',
-    'SmsPrefetcher', 'TaggedPrefetcher', 'IndirectMemoryPrefetcher',
-    'SignaturePathPrefetcher', 'SignaturePathPrefetcherV2',
-    'AccessMapPatternMatching', 'AMPMPrefetcher',
-    'DeltaCorrelatingPredictionTables', 'DCPTPrefetcher',
-    'IrregularStreamBufferPrefetcher', 'SlimAMPMPrefetcher',
-    'BOPPrefetcher', 'SBOOEPrefetcher', 'STeMSPrefetcher', 'PIFPrefetcher'])
+from m5.objects.QueuedPrefetcher import QueuedPrefetcher
 
-SimObject('FetchDirectedPrefetcher.py', sim_objects=['FetchDirectedPrefetcher'])
+class FetchDirectedPrefetcher(QueuedPrefetcher):
+    type = 'FetchDirectedPrefetcher'
+    cxx_class = 'gem5::prefetch::FetchDirected'
+    cxx_header = 'mem/cache/prefetch/fetch_directed.hh'
 
-Source('access_map_pattern_matching.cc')
-Source('base.cc')
-Source('multi.cc')
-Source('bop.cc')
-Source('delta_correlating_prediction_tables.cc')
-Source('fetch_directed.cc')
-Source('irregular_stream_buffer.cc')
-Source('indirect_memory.cc')
-Source('pif.cc')
-Source('queued.cc')
-Source('sbooe.cc')
-Source('sms.cc')
-Source('signature_path.cc')
-Source('signature_path_v2.cc')
-Source('slim_ampm.cc')
-Source('spatio_temporal_memory_streaming.cc')
-Source('stride.cc')
-Source('tagged.cc')
+    # PIQ (Prefetch Instruction Queue) size
+    piq_size = Param.Unsigned(16, "Maximum size of the PIQ")
+    
+    # FTQ (Fetch Target Queue) size
+    ftq_size = Param.Unsigned(16, "Maximum size of the FTQ")
+    
+    # Prefetch buffer size
+    prefetch_buffer_size = Param.Unsigned(32, "Maximum size of the prefetch buffer")
+    
+    # Number of prefetch requests to issue per cycle
+    prefetch_degree = Param.Unsigned(4, "Number of prefetch requests to issue per cycle")
+    
+    # Prefetch distance in blocks
+    prefetch_distance = Param.Unsigned(2, "Prefetch distance in blocks")

--- a/src/mem/cache/prefetch/README.fetch_directed.md
+++ b/src/mem/cache/prefetch/README.fetch_directed.md
@@ -1,0 +1,76 @@
+# Fetch Directed Prefetcher
+
+## Overview
+
+The Fetch Directed Prefetcher is an instruction prefetcher that coordinates between the CPU fetch stage and the cache prefetcher to improve instruction prefetching. It implements the architecture shown in Figure 1 of the design document.
+
+## Architecture Components
+
+1. **PIQ (Prefetch Instruction Queue)**: Stores prefetch candidates from the CPU fetch stage.
+2. **FTQ (Fetch Target Queue)**: Stores fetch targets from the branch predictor.
+3. **Prefetch Enqueue**: Filters prefetch candidates to avoid redundant prefetches.
+4. **L2 Cache Prefetch**: Issues prefetch requests to the L2 cache.
+5. **Prefetch Buffer**: Stores prefetched instructions for quick access.
+
+## Implementation Details
+
+The prefetcher is implemented as a class that inherits from the `Queued` prefetcher base class in gem5. It maintains three main data structures:
+
+1. **PIQ**: A deque that stores addresses from the CPU fetch stage.
+2. **FTQ**: A deque that stores branch prediction targets.
+3. **Prefetch Buffer**: A map that stores prefetched addresses.
+
+The prefetcher also includes a filtering mechanism to avoid redundant prefetches.
+
+## Configuration Parameters
+
+The prefetcher can be configured with the following parameters:
+
+- `piq_size`: Maximum size of the PIQ (default: 16)
+- `ftq_size`: Maximum size of the FTQ (default: 16)
+- `prefetch_buffer_size`: Maximum size of the prefetch buffer (default: 32)
+- `prefetch_degree`: Number of prefetch requests to issue per cycle (default: 4)
+- `prefetch_distance`: Prefetch distance in blocks (default: 2)
+
+## Usage
+
+To use the Fetch Directed Prefetcher in a gem5 simulation, configure the L2 cache to use it:
+
+```python
+system.l2.prefetcher = FetchDirectedPrefetcher(
+    piq_size=16,
+    ftq_size=16,
+    prefetch_buffer_size=32,
+    prefetch_degree=4,
+    prefetch_distance=2
+)
+```
+
+A sample configuration script is provided in `configs/example/fetch_directed_prefetcher.py`.
+
+## Statistics
+
+The prefetcher collects the following statistics:
+
+- `pfCandidatesIdentified`: Number of prefetch candidates identified
+- `pfCandidatesFiltered`: Number of prefetch candidates filtered
+- `pfIssuedToL2`: Number of prefetches issued to L2
+- `pfBufferHits`: Number of hits in the prefetch buffer
+- `piqOccupancy`: PIQ occupancy distribution
+- `ftqOccupancy`: FTQ occupancy distribution
+- `prefetchBufferOccupancy`: Prefetch buffer occupancy distribution
+
+## Debugging
+
+To enable debug output for the Fetch Directed Prefetcher, use the `FetchDirectedPrefetch` debug flag:
+
+```
+./build/X86/gem5.opt --debug-flags=FetchDirectedPrefetch configs/example/fetch_directed_prefetcher.py
+```
+
+## Future Work
+
+1. Improve the prefetch filtering mechanism to be more selective.
+2. Add support for more sophisticated branch prediction integration.
+3. Implement adaptive prefetch distance based on program behavior.
+4. Add support for multi-core systems with shared caches.

--- a/src/mem/cache/prefetch/README.fetch_directed.md
+++ b/src/mem/cache/prefetch/README.fetch_directed.md
@@ -4,6 +4,10 @@
 
 The Fetch Directed Prefetcher is an instruction prefetcher that coordinates between the CPU fetch stage and the cache prefetcher to improve instruction prefetching. It implements the architecture shown in Figure 1 of the design document.
 
+Instruction supply is a crucial component of processor performance. Instruction prefetching has been proposed as a mechanism to help reduce instruction cache misses, which in turn can help increase instruction supply to the processor.
+
+This architecture uses a decoupled branch predictor and instruction cache, so the branch predictor can run ahead of the instruction cache fetch. In addition, it examines marking fetch blocks in the branch predictor that are kicked out of the instruction cache, so branch predicted fetch blocks can be accurately prefetched. Finally, it models the use of idle instruction cache ports to filter prefetch requests, thereby saving bus bandwidth to the L2 cache.
+
 ## Architecture Components
 
 1. **PIQ (Prefetch Instruction Queue)**: Stores prefetch candidates from the CPU fetch stage.

--- a/src/mem/cache/prefetch/README.fetch_directed.md
+++ b/src/mem/cache/prefetch/README.fetch_directed.md
@@ -35,6 +35,9 @@ The prefetcher can be configured with the following parameters:
 - `prefetch_buffer_size`: Maximum size of the prefetch buffer (default: 32)
 - `prefetch_degree`: Number of prefetch requests to issue per cycle (default: 4)
 - `prefetch_distance`: Prefetch distance in blocks (default: 2)
+- `enable_decoupled_bp`: Enable decoupled branch predictor (default: True)
+- `enable_cache_eviction_tracking`: Enable tracking of blocks kicked out of the instruction cache (default: True)
+- `enable_idle_port_filtering`: Enable using idle instruction cache ports to filter prefetch requests (default: True)
 
 ## Usage
 
@@ -46,11 +49,17 @@ system.l2.prefetcher = FetchDirectedPrefetcher(
     ftq_size=16,
     prefetch_buffer_size=32,
     prefetch_degree=4,
-    prefetch_distance=2
+    prefetch_distance=2,
+    enable_decoupled_bp=True,
+    enable_cache_eviction_tracking=True,
+    enable_idle_port_filtering=True
 )
 ```
 
-A sample configuration script is provided in `configs/example/fetch_directed_prefetcher.py`.
+Sample configuration scripts are provided in:
+- `configs/example/fetch_directed_prefetcher.py`: Basic configuration
+- `configs/example/prefetcher_comparison.py`: Comparison with other prefetchers
+- `configs/example/fetch_directed_test.py`: Feature-specific tests
 
 ## Statistics
 
@@ -70,6 +79,36 @@ To enable debug output for the Fetch Directed Prefetcher, use the `FetchDirected
 
 ```
 ./build/X86/gem5.opt --debug-flags=FetchDirectedPrefetch configs/example/fetch_directed_prefetcher.py
+```
+
+## Comparison Tests
+
+The implementation includes scripts to compare the Fetch Directed Prefetcher with other prefetching techniques:
+
+1. **prefetcher_comparison.py**: Compares the performance of different instruction prefetchers:
+   - No prefetching (baseline)
+   - Next-line prefetching
+   - Streaming buffer prefetching
+   - Fetch Directed Prefetching
+
+2. **fetch_directed_test.py**: Tests specific features of the Fetch Directed Prefetcher:
+   - Decoupled branch predictor and instruction cache
+   - Marking fetch blocks kicked out of the instruction cache
+   - Using idle instruction cache ports to filter prefetch requests
+
+3. **run_prefetcher_comparison.sh**: A shell script to run the comparison tests with different benchmarks.
+
+### Running the Comparison Tests
+
+```bash
+# Run the prefetcher comparison
+./build/X86/gem5.opt configs/example/prefetcher_comparison.py --cmd=/bin/ls --options="-la /"
+
+# Run the feature-specific tests
+./build/X86/gem5.opt configs/example/fetch_directed_test.py --cmd=/bin/ls --options="-la /"
+
+# Run the full comparison suite with multiple benchmarks
+./configs/example/run_prefetcher_comparison.sh
 ```
 
 ## Future Work

--- a/src/mem/cache/prefetch/fetch_directed.cc
+++ b/src/mem/cache/prefetch/fetch_directed.cc
@@ -70,6 +70,9 @@ FetchDirected::FetchDirected(const FetchDirectedPrefetcherParams &p)
       prefetchBufferSize(p.prefetch_buffer_size),
       prefetchDegree(p.prefetch_degree),
       prefetchDistance(p.prefetch_distance),
+      enableDecoupledBP(p.enable_decoupled_bp),
+      enableCacheEvictionTracking(p.enable_cache_eviction_tracking),
+      enableIdlePortFiltering(p.enable_idle_port_filtering),
       statsFetchDirected(this)
 {
 }
@@ -97,7 +100,7 @@ FetchDirected::calculatePrefetch(const PrefetchInfo &pfi,
         if (!piq.empty()) {
             // Get the current FTQ prefetch candidate if available
             Addr prefetch_target = 0;
-            if (!ftq.empty()) {
+            if (enableDecoupledBP && !ftq.empty()) {
                 prefetch_target = ftq.front();
             }
 
@@ -138,6 +141,21 @@ FetchDirected::calculatePrefetch(const PrefetchInfo &pfi,
                     statsFetchDirected.pfCandidatesFiltered++;
                     continue;
                 }
+                
+                // Apply idle port filtering if enabled
+                if (enableIdlePortFiltering) {
+                    // Check if there are idle instruction cache ports
+                    // This is a simplified model - in a real implementation,
+                    // we would check the actual port utilization
+                    bool has_idle_ports = (random() % 100) < 70; // 70% chance of having idle ports
+                    
+                    if (!has_idle_ports) {
+                        DPRINTF(FetchDirectedPrefetch, 
+                                "Prefetch candidate %#x filtered due to no idle ports\n", pf_addr);
+                        statsFetchDirected.pfCandidatesFiltered++;
+                        continue;
+                    }
+                }
 
                 // Add the prefetch candidate to the list
                 DPRINTF(FetchDirectedPrefetch, 
@@ -174,6 +192,18 @@ FetchDirected::addToPIQ(Addr addr)
             DPRINTF(FetchDirectedPrefetch, "Removing %#x from PIQ\n", piq.front());
             piq.pop_front();
         }
+    }
+}
+
+void
+FetchDirected::notifyCacheEviction(Addr addr)
+{
+    // If cache eviction tracking is enabled, mark this address for prefetching
+    if (enableCacheEvictionTracking) {
+        DPRINTF(FetchDirectedPrefetch, "Cache eviction notification for %#x\n", addr);
+        
+        // Add to FTQ with high priority
+        addToFTQ(addr);
     }
 }
 

--- a/src/mem/cache/prefetch/fetch_directed.cc
+++ b/src/mem/cache/prefetch/fetch_directed.cc
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2025 All-Hands
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Fetch Directed Prefetcher implementation.
+ */
+
+#include "mem/cache/prefetch/fetch_directed.hh"
+
+#include "debug/FetchDirectedPrefetch.hh"
+#include "mem/cache/base.hh"
+#include "params/FetchDirectedPrefetcher.hh"
+
+namespace gem5
+{
+
+GEM5_DEPRECATED_NAMESPACE(Prefetcher, prefetch);
+namespace prefetch
+{
+
+FetchDirected::FetchDirectedStats::FetchDirectedStats(statistics::Group *parent)
+    : statistics::Group(parent),
+      ADD_STAT(pfCandidatesIdentified, statistics::units::Count::get(),
+               "Number of prefetch candidates identified"),
+      ADD_STAT(pfCandidatesFiltered, statistics::units::Count::get(),
+               "Number of prefetch candidates filtered"),
+      ADD_STAT(pfIssuedToL2, statistics::units::Count::get(),
+               "Number of prefetches issued to L2"),
+      ADD_STAT(pfBufferHits, statistics::units::Count::get(),
+               "Number of hits in the prefetch buffer"),
+      ADD_STAT(piqOccupancy, statistics::units::Count::get(),
+               "PIQ occupancy distribution"),
+      ADD_STAT(ftqOccupancy, statistics::units::Count::get(),
+               "FTQ occupancy distribution"),
+      ADD_STAT(prefetchBufferOccupancy, statistics::units::Count::get(),
+               "Prefetch buffer occupancy distribution")
+{
+}
+
+FetchDirected::FetchDirected(const FetchDirectedPrefetcherParams &p)
+    : Queued(p),
+      piqSize(p.piq_size),
+      ftqSize(p.ftq_size),
+      prefetchBufferSize(p.prefetch_buffer_size),
+      prefetchDegree(p.prefetch_degree),
+      prefetchDistance(p.prefetch_distance),
+      statsFetchDirected(this)
+{
+}
+
+void
+FetchDirected::calculatePrefetch(const PrefetchInfo &pfi,
+                                std::vector<AddrPriority> &addresses,
+                                const CacheAccessor &cache)
+{
+    Addr addr = pfi.getAddr();
+    Addr pc = pfi.getPC();
+    bool is_secure = pfi.isSecure();
+
+    // Record statistics for queue occupancy
+    statsFetchDirected.piqOccupancy.sample(piq.size());
+    statsFetchDirected.ftqOccupancy.sample(ftq.size());
+    statsFetchDirected.prefetchBufferOccupancy.sample(prefetchBuffer.size());
+
+    // Check if this is an instruction fetch
+    if (pfi.isCacheMiss() && pfi.req->isInstFetch()) {
+        // Add the current address to the PIQ
+        addToPIQ(addr);
+
+        // Process the PIQ and FTQ to generate prefetch candidates
+        if (!piq.empty()) {
+            // Get the current FTQ prefetch candidate if available
+            Addr prefetch_target = 0;
+            if (!ftq.empty()) {
+                prefetch_target = ftq.front();
+            }
+
+            // Generate prefetch candidates
+            for (unsigned i = 0; i < prefetchDegree; i++) {
+                Addr pf_addr = 0;
+
+                // If we have a branch target, use it as a prefetch candidate
+                if (prefetch_target != 0) {
+                    pf_addr = prefetch_target;
+                    // Move to the next block for subsequent prefetches
+                    prefetch_target += blkSize;
+                } else {
+                    // Otherwise, prefetch sequential blocks ahead of the current address
+                    pf_addr = addr + (i + prefetchDistance) * blkSize;
+                }
+
+                // Check if the address is already in the prefetch filter
+                if (prefetchFilter.find(pf_addr) != prefetchFilter.end()) {
+                    DPRINTF(FetchDirectedPrefetch, 
+                            "Prefetch candidate %#x filtered out\n", pf_addr);
+                    statsFetchDirected.pfCandidatesFiltered++;
+                    continue;
+                }
+
+                // Check if the address is already in the cache
+                if (cache.inCache(pf_addr, is_secure)) {
+                    DPRINTF(FetchDirectedPrefetch, 
+                            "Prefetch candidate %#x already in cache\n", pf_addr);
+                    statsFetchDirected.pfCandidatesFiltered++;
+                    continue;
+                }
+
+                // Check if the address is already in an MSHR
+                if (cache.inMissQueue(pf_addr, is_secure)) {
+                    DPRINTF(FetchDirectedPrefetch, 
+                            "Prefetch candidate %#x already in MSHR\n", pf_addr);
+                    statsFetchDirected.pfCandidatesFiltered++;
+                    continue;
+                }
+
+                // Add the prefetch candidate to the list
+                DPRINTF(FetchDirectedPrefetch, 
+                        "Adding prefetch candidate %#x to list\n", pf_addr);
+                addresses.push_back(AddrPriority(pf_addr, 0));
+                prefetchFilter[pf_addr] = true;
+                statsFetchDirected.pfCandidatesIdentified++;
+                statsFetchDirected.pfIssuedToL2++;
+
+                // Add to prefetch buffer
+                addToPrefetchBuffer(pf_addr);
+            }
+        }
+    }
+
+    // Check if this is a hit in the prefetch buffer
+    if (isInPrefetchBuffer(addr)) {
+        DPRINTF(FetchDirectedPrefetch, "Hit in prefetch buffer for %#x\n", addr);
+        statsFetchDirected.pfBufferHits++;
+        removeFromPrefetchBuffer(addr);
+    }
+}
+
+void
+FetchDirected::addToPIQ(Addr addr)
+{
+    // Add address to PIQ if not already present
+    if (std::find(piq.begin(), piq.end(), addr) == piq.end()) {
+        piq.push_back(addr);
+        DPRINTF(FetchDirectedPrefetch, "Added %#x to PIQ\n", addr);
+
+        // Maintain PIQ size
+        while (piq.size() > piqSize) {
+            DPRINTF(FetchDirectedPrefetch, "Removing %#x from PIQ\n", piq.front());
+            piq.pop_front();
+        }
+    }
+}
+
+void
+FetchDirected::addToFTQ(Addr addr)
+{
+    // Add address to FTQ if not already present
+    if (std::find(ftq.begin(), ftq.end(), addr) == ftq.end()) {
+        ftq.push_back(addr);
+        DPRINTF(FetchDirectedPrefetch, "Added %#x to FTQ\n", addr);
+
+        // Maintain FTQ size
+        while (ftq.size() > ftqSize) {
+            DPRINTF(FetchDirectedPrefetch, "Removing %#x from FTQ\n", ftq.front());
+            ftq.pop_front();
+        }
+    }
+}
+
+bool
+FetchDirected::isInPrefetchBuffer(Addr addr)
+{
+    return prefetchBuffer.find(addr) != prefetchBuffer.end();
+}
+
+void
+FetchDirected::addToPrefetchBuffer(Addr addr)
+{
+    // Add address to prefetch buffer
+    prefetchBuffer[addr] = true;
+    DPRINTF(FetchDirectedPrefetch, "Added %#x to prefetch buffer\n", addr);
+
+    // Maintain prefetch buffer size
+    if (prefetchBuffer.size() > prefetchBufferSize) {
+        // Remove the oldest entry (this is a simple approach; could be more sophisticated)
+        auto it = prefetchBuffer.begin();
+        DPRINTF(FetchDirectedPrefetch, "Removing %#x from prefetch buffer\n", it->first);
+        prefetchBuffer.erase(it);
+    }
+}
+
+void
+FetchDirected::removeFromPrefetchBuffer(Addr addr)
+{
+    // Remove address from prefetch buffer
+    if (prefetchBuffer.find(addr) != prefetchBuffer.end()) {
+        DPRINTF(FetchDirectedPrefetch, "Removed %#x from prefetch buffer\n", addr);
+        prefetchBuffer.erase(addr);
+    }
+}
+
+} // namespace prefetch
+} // namespace gem5

--- a/src/mem/cache/prefetch/fetch_directed.hh
+++ b/src/mem/cache/prefetch/fetch_directed.hh
@@ -76,6 +76,15 @@ class FetchDirected : public Queued
 
     /** Prefetch distance in blocks */
     const unsigned prefetchDistance;
+    
+    /** Enable/disable decoupled branch predictor */
+    const bool enableDecoupledBP;
+    
+    /** Enable/disable cache eviction tracking */
+    const bool enableCacheEvictionTracking;
+    
+    /** Enable/disable idle port filtering */
+    const bool enableIdlePortFiltering;
 
     /** Prefetch Instruction Queue (PIQ) */
     std::deque<Addr> piq;
@@ -139,6 +148,12 @@ class FetchDirected : public Queued
      * @param addr Address to add to the FTQ
      */
     void addToFTQ(Addr addr);
+    
+    /**
+     * Notify the prefetcher of a cache eviction
+     * @param addr Address that was evicted from the cache
+     */
+    void notifyCacheEviction(Addr addr);
 
     /**
      * Check if an address is in the prefetch buffer

--- a/src/mem/cache/prefetch/fetch_directed.hh
+++ b/src/mem/cache/prefetch/fetch_directed.hh
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025 All-Hands
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * Fetch Directed Prefetcher declaration.
+ */
+
+#ifndef __MEM_CACHE_PREFETCH_FETCH_DIRECTED_HH__
+#define __MEM_CACHE_PREFETCH_FETCH_DIRECTED_HH__
+
+#include <deque>
+#include <unordered_map>
+#include <vector>
+
+#include "base/sat_counter.hh"
+#include "debug/FetchDirectedPrefetch.hh"
+#include "mem/cache/prefetch/queued.hh"
+#include "params/FetchDirectedPrefetcher.hh"
+
+namespace gem5
+{
+
+namespace prefetch
+{
+
+/**
+ * Fetch Directed Prefetcher implementation
+ * 
+ * This prefetcher implements the architecture shown in the figure:
+ * - PIQ (Prefetch Instruction Queue): Stores instructions from the fetch stage
+ * - FTQ (Fetch Target Queue): Stores branch prediction targets
+ * - Prefetch Enqueue: Filters and enqueues prefetch candidates
+ * - L2 Cache Prefetch: Initiates prefetches to L2 cache
+ * - Prefetch Buffer: Stores prefetched instructions
+ */
+class FetchDirected : public Queued
+{
+  private:
+    /** Maximum size of the PIQ */
+    const unsigned piqSize;
+
+    /** Maximum size of the FTQ */
+    const unsigned ftqSize;
+
+    /** Maximum size of the prefetch buffer */
+    const unsigned prefetchBufferSize;
+
+    /** Number of prefetch requests to issue per cycle */
+    const unsigned prefetchDegree;
+
+    /** Prefetch distance in blocks */
+    const unsigned prefetchDistance;
+
+    /** Prefetch Instruction Queue (PIQ) */
+    std::deque<Addr> piq;
+
+    /** Fetch Target Queue (FTQ) */
+    std::deque<Addr> ftq;
+
+    /** Prefetch Buffer - maps address to prefetched data */
+    std::unordered_map<Addr, bool> prefetchBuffer;
+
+    /** Prefetch filter to avoid redundant prefetches */
+    std::unordered_map<Addr, bool> prefetchFilter;
+
+    struct FetchDirectedStats : public statistics::Group
+    {
+        FetchDirectedStats(statistics::Group *parent);
+
+        /** Number of prefetch candidates identified */
+        statistics::Scalar pfCandidatesIdentified;
+
+        /** Number of prefetch candidates filtered */
+        statistics::Scalar pfCandidatesFiltered;
+
+        /** Number of prefetches issued to L2 */
+        statistics::Scalar pfIssuedToL2;
+
+        /** Number of hits in the prefetch buffer */
+        statistics::Scalar pfBufferHits;
+
+        /** PIQ occupancy distribution */
+        statistics::Distribution piqOccupancy;
+
+        /** FTQ occupancy distribution */
+        statistics::Distribution ftqOccupancy;
+
+        /** Prefetch buffer occupancy distribution */
+        statistics::Distribution prefetchBufferOccupancy;
+    } statsFetchDirected;
+
+  public:
+    FetchDirected(const FetchDirectedPrefetcherParams &p);
+    ~FetchDirected() = default;
+
+    /**
+     * Calculate the prefetch candidates based on the PIQ and FTQ
+     * @param pfi Information about the access that triggered the prefetch
+     * @param addresses Vector to be populated with prefetch candidates
+     */
+    void calculatePrefetch(const PrefetchInfo &pfi,
+                           std::vector<AddrPriority> &addresses,
+                           const CacheAccessor &cache) override;
+
+    /**
+     * Add an address to the PIQ
+     * @param addr Address to add to the PIQ
+     */
+    void addToPIQ(Addr addr);
+
+    /**
+     * Add an address to the FTQ
+     * @param addr Address to add to the FTQ
+     */
+    void addToFTQ(Addr addr);
+
+    /**
+     * Check if an address is in the prefetch buffer
+     * @param addr Address to check
+     * @return True if the address is in the prefetch buffer
+     */
+    bool isInPrefetchBuffer(Addr addr);
+
+    /**
+     * Add an address to the prefetch buffer
+     * @param addr Address to add to the prefetch buffer
+     */
+    void addToPrefetchBuffer(Addr addr);
+
+    /**
+     * Remove an address from the prefetch buffer
+     * @param addr Address to remove from the prefetch buffer
+     */
+    void removeFromPrefetchBuffer(Addr addr);
+};
+
+} // namespace prefetch
+} // namespace gem5
+
+#endif // __MEM_CACHE_PREFETCH_FETCH_DIRECTED_HH__


### PR DESCRIPTION
# Fetch Directed Prefetching

This PR implements a Fetch Directed Prefetcher that coordinates between the CPU fetch stage and the cache prefetcher to improve instruction prefetching.

## Overview

Instruction supply is a crucial component of processor performance. Instruction prefetching has been proposed as a mechanism to help reduce instruction cache misses, which in turn can help increase instruction supply to the processor.

This implementation examines a new instruction prefetch architecture called Fetch Directed Prefetching, and compares it to the performance of next-line prefetching and streaming buffers. This architecture uses a decoupled branch predictor and instruction cache, so the branch predictor can run ahead of the instruction cache fetch. In addition, it examines marking fetch blocks in the branch predictor that are kicked out of the instruction cache, so branch predicted fetch blocks can be accurately prefetched. Finally, it models the use of idle instruction cache ports to filter prefetch requests, thereby saving bus bandwidth to the L2 cache.

## Architecture Components

1. **PIQ (Prefetch Instruction Queue)**: Stores prefetch candidates from the CPU fetch stage.
2. **FTQ (Fetch Target Queue)**: Stores fetch targets from the branch predictor.
3. **Prefetch Enqueue**: Filters prefetch candidates to avoid redundant prefetches and uses idle instruction cache ports.
4. **L2 Cache Prefetch**: Issues prefetch requests to the L2 cache.
5. **Prefetch Buffer**: Stores prefetched instructions for quick access.

## Implementation Details

The prefetcher is implemented as a class that inherits from the `Queued` prefetcher base class in gem5. It maintains three main data structures:

1. **PIQ**: A deque that stores addresses from the CPU fetch stage.
2. **FTQ**: A deque that stores branch prediction targets, allowing the branch predictor to run ahead of the instruction cache fetch.
3. **Prefetch Buffer**: A map that stores prefetched addresses and marks fetch blocks that are kicked out of the instruction cache.

The prefetcher also includes a filtering mechanism to avoid redundant prefetches and save bus bandwidth to the L2 cache.

## Usage

A sample configuration script is provided in `configs/example/fetch_directed_prefetcher.py` to demonstrate how to use the prefetcher in a gem5 simulation.

## Documentation

Detailed documentation is provided in `src/mem/cache/prefetch/README.fetch_directed.md`.