### PR TITLE
Implement Fetch Directed Instruction Prefetch (FDIP)

### DIFF
--- a/README.fdip
+++ b/README.fdip
@@ -1,0 +1,62 @@
+# Fetch Directed Instruction Prefetching (FDIP)
+
+## Overview
+
+Fetch Directed Instruction Prefetching (FDIP) is a prefetching technique that uses branch prediction to guide instruction prefetching. The prefetcher works by predicting future branch targets and prefetching instructions along the predicted path.
+
+## Architecture
+
+The FDIP implementation consists of the following components:
+
+1. **Branch Predictor**: Predicts branch targets ahead of the prefetcher
+2. **PIQ (Program Information Queue)**: Stores information about program execution for prefetching
+3. **FTQ (Fetch Target Queue)**: Stores predicted branch targets from the branch predictor
+4. **Prefetch Enqueue**: Filters and enqueues prefetch candidates
+5. **L2 Cache Prefetch**: Prefetches instructions into the L2 cache
+6. **Prefetch Buffer**: Stores prefetched instructions for the instruction fetch unit
+
+## Key Features
+
+- Branch predictor works ahead of the prefetcher to provide early branch predictions
+- Configurable branch predictor lookahead to control how far ahead the branch predictor works
+- Filtration mechanisms to reduce unnecessary prefetches
+- Support for different branch predictor types (TAGE, Tournament)
+- Configurable queue sizes for PIQ, FTQ, and Prefetch Buffer
+
+## Parameters
+
+- `degree`: Number of cache lines to prefetch
+- `use_tage`: Whether to use the TAGE branch predictor
+- `thread_id`: Thread ID for the branch predictor
+- `line_size`: Cache line size
+- `max_lookahead`: Maximum number of branches to look ahead
+- `cleanup_interval`: Interval for cleaning up old prefetched addresses
+- `confidence_threshold`: Minimum confidence threshold for branch predictions
+- `piq_size`: Maximum size of the PIQ
+- `ftq_size`: Maximum size of the FTQ
+- `prefetch_buffer_size`: Maximum size of the Prefetch Buffer
+- `branch_predictor_lookahead`: How far ahead the branch predictor should work compared to the prefetcher
+
+## Usage
+
+To use FDIP in your gem5 simulation, add the following to your configuration script:
+
+```python
+system.cpu.icache.prefetcher = FDIP(
+    degree=2,
+    use_tage=True,
+    thread_id=0,
+    line_size=64,
+    max_lookahead=16,
+    cleanup_interval=1000,
+    confidence_threshold=50,
+    piq_size=16,
+    ftq_size=16,
+    prefetch_buffer_size=16,
+    branch_predictor_lookahead=32
+)
+```
+
+## Example
+
+See `configs/example/fdip_example.py` for a complete example of how to use FDIP in a gem5 simulation.

--- a/configs/example/fdip_example.py
+++ b/configs/example/fdip_example.py
@@ -18,6 +18,7 @@ in gem5. It compares FDIP with next-line prefetching.
 
 import argparse
 import sys
+import os
 
 import m5
 from m5.objects import *
@@ -96,6 +97,12 @@ parser.add_argument("--prefetch-degree", type=int, default=2,
                     help="Prefetch degree (number of blocks to prefetch)")
 parser.add_argument("--max-lookahead", type=int, default=16,
                     help="Maximum number of instructions to look ahead for FDIP")
+parser.add_argument("--confidence-threshold", type=int, default=50,
+                    help="Minimum confidence threshold for FDIP (0-100)")
+parser.add_argument("--max-streams", type=int, default=16,
+                    help="Maximum number of branch streams to track")
+parser.add_argument("--dedicated-predictor", action="store_true",
+                    help="Use a dedicated branch predictor for FDIP")
 
 options = parser.parse_args()
 
@@ -183,21 +190,55 @@ system.l2cache.connectCPUSideBus(system.l2bus)
 
 # Configure the prefetcher
 if options.prefetcher == "fdip":
+    # Create TAGE parameters if using a dedicated predictor
+    if options.dedicated_predictor:
+        tage_params = TAGE()
+        tournament_params = TournamentBP()
+    else:
+        tage_params = TAGE()
+        tournament_params = TournamentBP()
+    
     # Use FDIP prefetcher
-    system.l2cache.prefetcher = FDIPrefetcher(degree=options.prefetch_degree,
-                                             max_lookahead=options.max_lookahead,
-                                             use_tage=True,
-                                             thread_id=0)
+    system.l2cache.prefetcher = FDIPrefetcher(
+        degree=options.prefetch_degree,
+        max_lookahead=options.max_lookahead,
+        use_tage=True,
+        thread_id=0,
+        confidence_threshold=options.confidence_threshold,
+        max_streams=options.max_streams,
+        create_dedicated_predictor=options.dedicated_predictor,
+        tage_params=tage_params,
+        tournament_params=tournament_params
+    )
     
-    # We need to connect the branch predictor to the prefetcher after the system is instantiated
-    # This will be done in a callback function
-    def connectBranchPredictor(root):
-        for cpu in root.system.cpu:
-            if hasattr(root.system.l2cache, 'prefetcher'):
-                root.system.l2cache.prefetcher.setBranchPredictor(cpu.getBranchPredictor())
+    # If not using a dedicated predictor, connect to the CPU's branch predictor
+    if not options.dedicated_predictor:
+        # We need to connect the branch predictor to the prefetcher after the system is instantiated
+        # This will be done in a callback function
+        def connectBranchPredictor(root):
+            for cpu in root.system.cpu:
+                if hasattr(root.system.l2cache, 'prefetcher'):
+                    root.system.l2cache.prefetcher.setBranchPredictor(cpu.getBranchPredictor())
+        
+        # Register the callback to be called after instantiation
+        m5.registerCallback(connectBranchPredictor)
     
-    # Register the callback to be called after instantiation
-    m5.registerCallback(connectBranchPredictor)
+    # Register callbacks for branch misprediction notifications
+    def notifyBranchMisprediction(pc, target, confidence=0, cpu_num=0):
+        """Notify the prefetcher about a branch misprediction"""
+        if hasattr(system.l2cache, 'prefetcher'):
+            system.l2cache.prefetcher.notifyBranchMisprediction(pc, target, confidence)
+    
+    def notifyCorrectPrediction(pc, target, confidence=0, cpu_num=0):
+        """Notify the prefetcher about a correct branch prediction"""
+        if hasattr(system.l2cache, 'prefetcher'):
+            system.l2cache.prefetcher.notifyCorrectPrediction(pc, target, confidence)
+    
+    # Hook these callbacks into the CPU's branch predictor
+    for cpu in system.cpu:
+        cpu.branchPred.mispredictHandler = notifyBranchMisprediction
+        cpu.branchPred.correctPredictHandler = notifyCorrectPrediction
+    
 elif options.prefetcher == "stride":
     # Use stride prefetcher
     system.l2cache.prefetcher = StridePrefetcher(degree=options.prefetch_degree)

--- a/configs/example/fdip_example.py
+++ b/configs/example/fdip_example.py
@@ -103,6 +103,12 @@ parser.add_argument("--max-streams", type=int, default=16,
                     help="Maximum number of branch streams to track")
 parser.add_argument("--dedicated-predictor", action="store_true",
                     help="Use a dedicated branch predictor for FDIP")
+parser.add_argument("--piq-size", type=int, default=32,
+                    help="Maximum size of the PIQ (Program Information Queue)")
+parser.add_argument("--ftq-size", type=int, default=16,
+                    help="Maximum size of the FTQ (Fetch Target Queue)")
+parser.add_argument("--prefetch-buffer-size", type=int, default=16,
+                    help="Maximum size of the Prefetch Buffer")
 
 options = parser.parse_args()
 
@@ -210,7 +216,10 @@ if options.prefetcher == "fdip":
             max_streams=options.max_streams,
             create_dedicated_predictor=options.dedicated_predictor,
             tage_params=tage_params,
-            tournament_params=tournament_params
+            tournament_params=tournament_params,
+            piq_size=options.piq_size,
+            ftq_size=options.ftq_size,
+            prefetch_buffer_size=options.prefetch_buffer_size
         )
     
     # If not using a dedicated predictor, connect to the CPU's branch predictor

--- a/configs/example/fdip_example.py
+++ b/configs/example/fdip_example.py
@@ -198,18 +198,20 @@ if options.prefetcher == "fdip":
         tage_params = TAGE()
         tournament_params = TournamentBP()
     
-    # Use FDIP prefetcher
-    system.l2cache.prefetcher = FDIPrefetcher(
-        degree=options.prefetch_degree,
-        max_lookahead=options.max_lookahead,
-        use_tage=True,
-        thread_id=0,
-        confidence_threshold=options.confidence_threshold,
-        max_streams=options.max_streams,
-        create_dedicated_predictor=options.dedicated_predictor,
-        tage_params=tage_params,
-        tournament_params=tournament_params
-    )
+    # Use FDIP prefetcher in the L1 instruction cache
+    for cpu in system.cpu:
+        # Add FDIP prefetcher to each CPU's L1 instruction cache
+        cpu.icache.prefetcher = FDIPrefetcher(
+            degree=options.prefetch_degree,
+            max_lookahead=options.max_lookahead,
+            use_tage=True,
+            thread_id=0,
+            confidence_threshold=options.confidence_threshold,
+            max_streams=options.max_streams,
+            create_dedicated_predictor=options.dedicated_predictor,
+            tage_params=tage_params,
+            tournament_params=tournament_params
+        )
     
     # If not using a dedicated predictor, connect to the CPU's branch predictor
     if not options.dedicated_predictor:
@@ -217,8 +219,8 @@ if options.prefetcher == "fdip":
         # This will be done in a callback function
         def connectBranchPredictor(root):
             for cpu in root.system.cpu:
-                if hasattr(root.system.l2cache, 'prefetcher'):
-                    root.system.l2cache.prefetcher.setBranchPredictor(cpu.getBranchPredictor())
+                if hasattr(cpu.icache, 'prefetcher'):
+                    cpu.icache.prefetcher.setBranchPredictor(cpu.getBranchPredictor())
         
         # Register the callback to be called after instantiation
         m5.registerCallback(connectBranchPredictor)
@@ -226,13 +228,13 @@ if options.prefetcher == "fdip":
     # Register callbacks for branch misprediction notifications
     def notifyBranchMisprediction(pc, target, confidence=0, cpu_num=0):
         """Notify the prefetcher about a branch misprediction"""
-        if hasattr(system.l2cache, 'prefetcher'):
-            system.l2cache.prefetcher.notifyBranchMisprediction(pc, target, confidence)
+        if cpu_num < len(system.cpu) and hasattr(system.cpu[cpu_num].icache, 'prefetcher'):
+            system.cpu[cpu_num].icache.prefetcher.notifyBranchMisprediction(pc, target, confidence)
     
     def notifyCorrectPrediction(pc, target, confidence=0, cpu_num=0):
         """Notify the prefetcher about a correct branch prediction"""
-        if hasattr(system.l2cache, 'prefetcher'):
-            system.l2cache.prefetcher.notifyCorrectPrediction(pc, target, confidence)
+        if cpu_num < len(system.cpu) and hasattr(system.cpu[cpu_num].icache, 'prefetcher'):
+            system.cpu[cpu_num].icache.prefetcher.notifyCorrectPrediction(pc, target, confidence)
     
     # Hook these callbacks into the CPU's branch predictor
     for cpu in system.cpu:
@@ -240,11 +242,13 @@ if options.prefetcher == "fdip":
         cpu.branchPred.correctPredictHandler = notifyCorrectPrediction
     
 elif options.prefetcher == "stride":
-    # Use stride prefetcher
-    system.l2cache.prefetcher = StridePrefetcher(degree=options.prefetch_degree)
+    # Use stride prefetcher in the L1 instruction cache
+    for cpu in system.cpu:
+        cpu.icache.prefetcher = StridePrefetcher(degree=options.prefetch_degree)
 else:
     # No prefetcher
-    system.l2cache.prefetcher = NULL
+    for cpu in system.cpu:
+        cpu.icache.prefetcher = NULL
 
 # Create a memory bus
 system.membus = SystemXBar()

--- a/configs/example/fdip_example.py
+++ b/configs/example/fdip_example.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2024 All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+
+"""
+This script demonstrates how to use the Fetch Directed Instruction Prefetching (FDIP)
+in gem5. It compares FDIP with next-line prefetching.
+"""
+
+import argparse
+import sys
+
+import m5
+from m5.objects import *
+from m5.util import addToPath
+
+addToPath('../')
+
+from common import Options
+from common import Simulation
+from common import CacheConfig
+from common import MemConfig
+from common.Caches import *
+
+def get_processes(options):
+    """Interprets provided options and returns a list of processes"""
+
+    multiprocesses = []
+    inputs = []
+    outputs = []
+    errouts = []
+    pargs = []
+
+    workloads = options.cmd.split(';')
+    if options.input != "":
+        inputs = options.input.split(';')
+    if options.output != "":
+        outputs = options.output.split(';')
+    if options.errout != "":
+        errouts = options.errout.split(';')
+    if options.options != "":
+        pargs = options.options.split(';')
+
+    idx = 0
+    for wrkld in workloads:
+        process = Process(pid = 100 + idx)
+        process.executable = wrkld
+        process.cwd = os.getcwd()
+
+        if options.env:
+            with open(options.env, 'r') as f:
+                process.env = [line.rstrip() for line in f]
+
+        if len(pargs) > idx:
+            process.cmd = [wrkld] + pargs[idx].split()
+        else:
+            process.cmd = [wrkld]
+
+        if len(inputs) > idx:
+            process.input = inputs[idx]
+        if len(outputs) > idx:
+            process.output = outputs[idx]
+        if len(errouts) > idx:
+            process.errout = errouts[idx]
+
+        multiprocesses.append(process)
+        idx += 1
+
+    if options.smt:
+        assert(options.cpu_type == "DerivO3CPU")
+        return multiprocesses
+    else:
+        return multiprocesses[0]
+
+parser = argparse.ArgumentParser()
+Options.addCommonOptions(parser)
+Options.addSEOptions(parser)
+
+parser.add_argument("--prefetcher", type=str, default="fdip",
+                    choices=["fdip", "stride", "none"],
+                    help="Type of prefetcher to use")
+parser.add_argument("--l2_size", type=str, default="2MB",
+                    help="L2 cache size")
+parser.add_argument("--l2_assoc", type=int, default=8,
+                    help="L2 cache associativity")
+parser.add_argument("--prefetch-degree", type=int, default=2,
+                    help="Prefetch degree (number of blocks to prefetch)")
+parser.add_argument("--max-lookahead", type=int, default=16,
+                    help="Maximum number of instructions to look ahead for FDIP")
+
+options = parser.parse_args()
+
+multiprocesses = []
+numThreads = 1
+
+if options.bench:
+    apps = options.bench.split("-")
+    if len(apps) != options.num_cpus:
+        print("number of benchmarks not equal to set num_cpus!")
+        sys.exit(1)
+
+    for app in apps:
+        try:
+            if buildEnv['TARGET_ISA'] == 'arm':
+                exec("workload = %s('arm_%s', 'linux', '%s')" % (
+                        app, options.arm_iset, options.spec_input))
+            else:
+                exec("workload = %s(buildEnv['TARGET_ISA', 'linux', '%s')" % (
+                        app, options.spec_input))
+            multiprocesses.append(workload.makeProcess())
+        except:
+            print("Unable to find workload for %s: %s" %
+                  (buildEnv['TARGET_ISA'], app),
+                  file=sys.stderr)
+            sys.exit(1)
+elif options.cmd:
+    multiprocesses = get_processes(options)
+else:
+    print("No workload specified. Exiting!\n", file=sys.stderr)
+    sys.exit(1)
+
+# Create the system
+system = System(cpu = [DerivO3CPU(cpu_id=0)],
+                mem_mode = 'timing',
+                mem_ranges = [AddrRange(options.mem_size)],
+                cache_line_size = 64)
+
+# Create a top-level voltage domain
+system.voltage_domain = VoltageDomain(voltage = options.sys_voltage)
+
+# Create a source clock for the system and set the clock period
+system.clk_domain = SrcClockDomain(clock = options.sys_clock,
+                                   voltage_domain = system.voltage_domain)
+
+# Create a CPU voltage domain
+system.cpu_voltage_domain = VoltageDomain()
+
+# Create a source clock for the CPUs and set the clock period
+system.cpu_clk_domain = SrcClockDomain(clock = options.cpu_clock,
+                                       voltage_domain = system.cpu_voltage_domain)
+
+# All CPUs belong to a common CPU clock domain
+for cpu in system.cpu:
+    cpu.clk_domain = system.cpu_clk_domain
+
+# Setup the workload
+if isinstance(multiprocesses, list):
+    for cpu, workload in zip(system.cpu, multiprocesses):
+        cpu.workload = workload
+        cpu.createThreads()
+else:
+    system.cpu[0].workload = multiprocesses
+    system.cpu[0].createThreads()
+
+# Create the L1 instruction and data caches
+for cpu in system.cpu:
+    # Create an L1 instruction and data cache
+    cpu.icache = L1_ICache(size='32kB', assoc=2)
+    cpu.dcache = L1_DCache(size='32kB', assoc=2)
+    
+    # Connect the instruction and data caches to the CPU
+    cpu.icache.connectCPU(cpu)
+    cpu.dcache.connectCPU(cpu)
+
+# Create an L2 cache and connect it to the L1 caches
+system.l2bus = L2XBar()
+for cpu in system.cpu:
+    cpu.icache.connectBus(system.l2bus)
+    cpu.dcache.connectBus(system.l2bus)
+
+# Create an L2 cache
+system.l2cache = L2Cache(size=options.l2_size, assoc=options.l2_assoc)
+system.l2cache.connectCPUSideBus(system.l2bus)
+
+# Configure the prefetcher
+if options.prefetcher == "fdip":
+    # Use FDIP prefetcher
+    system.l2cache.prefetcher = FDIPrefetcher(degree=options.prefetch_degree,
+                                             max_lookahead=options.max_lookahead,
+                                             use_tage=True,
+                                             thread_id=0)
+    
+    # We need to connect the branch predictor to the prefetcher after the system is instantiated
+    # This will be done in a callback function
+    def connectBranchPredictor(root):
+        for cpu in root.system.cpu:
+            if hasattr(root.system.l2cache, 'prefetcher'):
+                root.system.l2cache.prefetcher.setBranchPredictor(cpu.getBranchPredictor())
+    
+    # Register the callback to be called after instantiation
+    m5.registerCallback(connectBranchPredictor)
+elif options.prefetcher == "stride":
+    # Use stride prefetcher
+    system.l2cache.prefetcher = StridePrefetcher(degree=options.prefetch_degree)
+else:
+    # No prefetcher
+    system.l2cache.prefetcher = NULL
+
+# Create a memory bus
+system.membus = SystemXBar()
+system.l2cache.connectMemSideBus(system.membus)
+
+# Connect the system up to the membus
+system.system_port = system.membus.cpu_side_ports
+
+# Create a memory controller and connect it to the membus
+system.mem_ctrl = MemCtrl()
+system.mem_ctrl.dram = DDR4_2400_8x8()
+system.mem_ctrl.dram.range = system.mem_ranges[0]
+system.mem_ctrl.port = system.membus.mem_side_ports
+
+# Set up the system
+root = Root(full_system = False, system = system)
+
+# Instantiate the system
+m5.instantiate()
+
+# Simulate until program terminates
+print("Beginning simulation!")
+exit_event = m5.simulate()
+print('Exiting @ tick {} because {}'
+      .format(m5.curTick(), exit_event.getCause()))

--- a/configs/example/fdip_example.py
+++ b/configs/example/fdip_example.py
@@ -109,6 +109,8 @@ parser.add_argument("--ftq-size", type=int, default=16,
                     help="Maximum size of the FTQ (Fetch Target Queue)")
 parser.add_argument("--prefetch-buffer-size", type=int, default=16,
                     help="Maximum size of the Prefetch Buffer")
+parser.add_argument("--branch-predictor-lookahead", type=int, default=32,
+                    help="How far ahead the branch predictor should work compared to the prefetcher")
 
 options = parser.parse_args()
 
@@ -219,7 +221,8 @@ if options.prefetcher == "fdip":
             tournament_params=tournament_params,
             piq_size=options.piq_size,
             ftq_size=options.ftq_size,
-            prefetch_buffer_size=options.prefetch_buffer_size
+            prefetch_buffer_size=options.prefetch_buffer_size,
+            branch_predictor_lookahead=options.branch_predictor_lookahead
         )
     
     # If not using a dedicated predictor, connect to the CPU's branch predictor

--- a/src/cpu/o3/cpu.hh
+++ b/src/cpu/o3/cpu.hh
@@ -590,6 +590,14 @@ class CPU : public BaseCPU
     // hardware transactional memory
     void htmSendAbortSignal(ThreadID tid, uint64_t htm_uid,
                             HtmFailureFaultCause cause) override;
+                            
+    /**
+     * Get the branch predictor unit
+     * @return Pointer to the branch predictor unit
+     */
+    branch_prediction::BPredUnit* getBranchPredictor() {
+        return fetch.branchPred;
+    }
 };
 
 } // namespace o3

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -414,6 +414,9 @@ class Fetch
 
     /** BPredUnit. */
     branch_prediction::BPredUnit *branchPred;
+    
+    /** Make CPU class a friend to access branchPred */
+    friend class CPU;
 
     std::unique_ptr<PCStateBase> pc[MaxThreads];
 

--- a/src/cpu/pred/bpred_unit.cc
+++ b/src/cpu/pred/bpred_unit.cc
@@ -64,8 +64,22 @@ BPredUnit::BPredUnit(const Params &params)
       btb(params.btb),
       ras(params.ras),
       iPred(params.indirectBranchPred),
+      mispredictHandler(nullptr),
+      correctPredictHandler(nullptr),
       stats(this)
 {
+}
+
+void
+BPredUnit::setMispredictionHandler(MispredictionHandler handler)
+{
+    mispredictHandler = handler;
+}
+
+void
+BPredUnit::setCorrectPredictionHandler(CorrectPredictionHandler handler)
+{
+    correctPredictHandler = handler;
 }
 
 
@@ -366,6 +380,13 @@ BPredUnit::commitBranch(ThreadID tid, PredictorHistory* &hist)
                 hist->seqNum, hist->pc, toString(hist->type),
                 hist->predTaken, hist->actuallyTaken,
                 hist->target->instAddr());
+                
+    // Call the correct prediction handler if registered and not mispredicted
+    if (correctPredictHandler && !hist->mispredict) {
+        DPRINTF(Branch, "[tid:%i] Calling correct prediction handler for PC:%#x, "
+                "target:%#x\n", tid, hist->pc, hist->target->instAddr());
+        correctPredictHandler(hist->pc, hist->target->instAddr(), 0);
+    }
 
     // Update the branch predictor with the correct results.
     update(tid, hist->pc,
@@ -521,6 +542,13 @@ BPredUnit::squash(const InstSeqNum &squashed_sn,
         hist->mispredict = true;
         hist->actuallyTaken = actually_taken;
         set(hist->target,  corr_target);
+        
+        // Call the misprediction handler if registered
+        if (mispredictHandler) {
+            DPRINTF(Branch, "[tid:%i] Calling misprediction handler for PC:%#x, "
+                    "target:%#x\n", tid, hist->pc, corr_target.instAddr());
+            mispredictHandler(hist->pc, corr_target.instAddr(), 0);
+        }
 
         // Correct Direction predictor ------------------
         update(tid, hist->pc, actually_taken, hist->bpHistory,

--- a/src/cpu/pred/bpred_unit.hh
+++ b/src/cpu/pred/bpred_unit.hh
@@ -43,6 +43,7 @@
 #define __CPU_PRED_BPRED_UNIT_HH__
 
 #include <deque>
+#include <functional>
 
 #include "base/statistics.hh"
 #include "base/types.hh"
@@ -74,6 +75,33 @@ class BPredUnit : public SimObject
 
     /** Branch Predictor Unit (BPU) interface functions */
   public:
+    /**
+     * Type definition for branch misprediction notification callback
+     * @param pc Program counter of the mispredicted branch
+     * @param target Actual target of the branch
+     * @param cpu_num CPU number (for multi-core systems)
+     */
+    typedef std::function<void(Addr pc, Addr target, unsigned cpu_num)> MispredictionHandler;
+    
+    /**
+     * Type definition for correct prediction notification callback
+     * @param pc Program counter of the correctly predicted branch
+     * @param target Target of the branch
+     * @param cpu_num CPU number (for multi-core systems)
+     */
+    typedef std::function<void(Addr pc, Addr target, unsigned cpu_num)> CorrectPredictionHandler;
+    
+    /**
+     * Callback for branch misprediction notification
+     * This is called when a branch is mispredicted
+     */
+    MispredictionHandler mispredictHandler;
+    
+    /**
+     * Callback for correct prediction notification
+     * This is called when a branch is correctly predicted
+     */
+    CorrectPredictionHandler correctPredictHandler;
 
 
 

--- a/src/mem/cache/SConscript
+++ b/src/mem/cache/SConscript
@@ -62,10 +62,11 @@ DebugFlag('HWPrefetch')
 DebugFlag('MSHR')
 DebugFlag('HWPrefetchQueue')
 DebugFlag('PartitionPolicy')
+DebugFlag('FDIP')
 
 # CacheTags is so outrageously verbose, printing the cache's entire tag
 # array on each timing access, that you should probably have to ask for
 # it explicitly even above and beyond CacheAll.
 CompoundFlag('CacheAll', ['Cache', 'CacheComp', 'CachePort', 'CacheRepl',
                           'CacheVerbose', 'HWPrefetch', 'MSHR',
-                          'PartitionPolicy'])
+                          'PartitionPolicy', 'FDIP'])

--- a/src/mem/cache/prefetch/FDIPrefetcher.py
+++ b/src/mem/cache/prefetch/FDIPrefetcher.py
@@ -36,3 +36,27 @@ class FDIPrefetcher(QueuedPrefetcher):
     
     # Cleanup interval for the prefetched addresses map
     cleanup_interval = Param.Tick(1000000, "Cleanup interval for the prefetched addresses map")
+    
+    # Minimum confidence threshold for branch predictions (0-100)
+    confidence_threshold = Param.Unsigned(50, "Minimum confidence threshold for branch predictions (0-100)")
+    
+    # Whether to create a dedicated branch predictor for FDIP
+    create_dedicated_predictor = Param.Bool(False, "Whether to create a dedicated branch predictor for FDIP")
+    
+    # TAGE branch predictor parameters (used if create_dedicated_predictor is True and use_tage is True)
+    tage_params = Param.TAGE(NULL, "TAGE branch predictor parameters")
+    
+    # Tournament branch predictor parameters (used if create_dedicated_predictor is True and use_tage is False)
+    tournament_params = Param.BranchPredictor(NULL, "Tournament branch predictor parameters")
+    
+    # Maximum size of the PIQ (Program Information Queue)
+    piq_size = Param.Unsigned(32, "Maximum size of the PIQ (Program Information Queue)")
+    
+    # Maximum size of the FTQ (Fetch Target Queue)
+    ftq_size = Param.Unsigned(16, "Maximum size of the FTQ (Fetch Target Queue)")
+    
+    # Maximum size of the Prefetch Buffer
+    prefetch_buffer_size = Param.Unsigned(16, "Maximum size of the Prefetch Buffer")
+    
+    # Maximum number of branch streams to track
+    max_streams = Param.Unsigned(16, "Maximum number of branch streams to track")

--- a/src/mem/cache/prefetch/FDIPrefetcher.py
+++ b/src/mem/cache/prefetch/FDIPrefetcher.py
@@ -60,3 +60,6 @@ class FDIPrefetcher(QueuedPrefetcher):
     
     # Maximum number of branch streams to track
     max_streams = Param.Unsigned(16, "Maximum number of branch streams to track")
+    
+    # How far ahead the branch predictor should work compared to the prefetcher
+    branch_predictor_lookahead = Param.Unsigned(32, "How far ahead the branch predictor should work compared to the prefetcher")

--- a/src/mem/cache/prefetch/FDIPrefetcher.py
+++ b/src/mem/cache/prefetch/FDIPrefetcher.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2024 All rights reserved
+#
+# The license below extends only to copyright in the software and shall
+# not be construed as granting a license to any other intellectual
+# property including but not limited to intellectual property relating
+# to a hardware implementation of the functionality of the software
+# licensed hereunder.  You may use the software subject to the license
+# terms below provided that you ensure that this notice is replicated
+# unmodified and in its entirety in all distributions of the software,
+# modified or unmodified, in source code or in binary form.
+
+from m5.params import *
+from m5.proxy import *
+
+from m5.objects.QueuedPrefetcher import QueuedPrefetcher
+
+class FDIPrefetcher(QueuedPrefetcher):
+    type = 'FDIPrefetcher'
+    cxx_class = 'gem5::prefetch::FDIP'
+    cxx_header = 'mem/cache/prefetch/fdip.hh'
+
+    # Number of cache lines to prefetch
+    degree = Param.Unsigned(2, "Number of cache lines to prefetch")
+    
+    # Whether to use TAGE branch predictor
+    use_tage = Param.Bool(True, "Whether to use TAGE branch predictor")
+    
+    # Thread ID to use for branch prediction (single thread support)
+    thread_id = Param.Unsigned(0, "Thread ID to use for branch prediction")
+    
+    # Cache line size in bytes
+    line_size = Param.Unsigned(64, "Cache line size in bytes")
+    
+    # Maximum number of instructions to look ahead for prefetching
+    max_lookahead = Param.Unsigned(16, "Maximum number of instructions to look ahead")
+    
+    # Cleanup interval for the prefetched addresses map
+    cleanup_interval = Param.Tick(1000000, "Cleanup interval for the prefetched addresses map")

--- a/src/mem/cache/prefetch/README.fdip
+++ b/src/mem/cache/prefetch/README.fdip
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Fetch Directed Instruction Prefetching (FDIP) is a technique that uses branch predictor results to guide instruction prefetching. This implementation uses the TAGE branch predictor to predict future instruction addresses and prefetch them into the cache.
+Fetch Directed Instruction Prefetching (FDIP) is a technique that uses branch predictor results to guide instruction prefetching. This implementation uses the TAGE branch predictor to predict future instruction addresses and prefetch them into the L1 instruction cache.
 
 ## Features
 
@@ -20,7 +20,7 @@ The FDIP prefetcher works by:
 
 1. Using the branch predictor to predict future branch targets
 2. Tracking prediction confidence to filter out low-quality predictions
-3. Prefetching cache lines containing those targets
+3. Prefetching cache lines containing those targets into the L1 instruction cache
 4. Tracking prefetched addresses to avoid redundant prefetches
 5. Handling misprediction cases through a notification mechanism
 6. Maintaining branch prediction streams to adapt to program behavior

--- a/src/mem/cache/prefetch/README.fdip
+++ b/src/mem/cache/prefetch/README.fdip
@@ -2,28 +2,51 @@
 
 ## Overview
 
-Fetch Directed Instruction Prefetching (FDIP) is a technique that uses branch predictor results to guide instruction prefetching. This implementation uses the TAGE branch predictor to predict future instruction addresses and prefetch them into the L1 instruction cache.
+Fetch Directed Instruction Prefetching (FDIP) is a technique that uses branch predictor results to guide instruction prefetching. This implementation uses the branch predictor to predict future instruction addresses and prefetch them into the instruction cache.
+
+## Architecture
+
+The FDIP implementation follows the architecture shown in the diagram with the following components:
+
+1. **PIQ (Program Information Queue)**: Stores information about program execution for prefetching
+2. **FTQ (Fetch Target Queue)**: Stores branch prediction targets from the branch predictor
+3. **Prefetch Enqueue**: Contains filtration mechanisms to select prefetch candidates
+4. **L2 Cache Prefetch**: Prefetches instructions into the L2 cache
+5. **Prefetch Buffer**: Stores prefetched cache lines before they are consumed by instruction fetch
+6. **Branch Predictor**: Provides branch prediction information to guide prefetching
+7. **Instruction Fetch**: Consumes prefetched instructions from the Prefetch Buffer
+
+The data flow in the FDIP architecture is as follows:
+
+1. The Branch Predictor predicts branch targets and feeds them into the FTQ
+2. The FTQ provides prefetch candidates to the Prefetch Enqueue and Instruction Fetch
+3. The Prefetch Enqueue applies filtration mechanisms to select prefetch candidates
+4. The PIQ receives information from the Prefetch Enqueue and feeds the L2 Cache Prefetch
+5. The L2 Cache Prefetch prefetches instructions into the Prefetch Buffer
+6. The Prefetch Buffer feeds prefetched instructions to the Instruction Fetch
 
 ## Features
 
-- Uses branch predictor results (specifically TAGE predictor) to guide prefetching
+- Uses branch predictor results to guide prefetching
 - Handles misprediction cases through a dedicated notification mechanism
 - Supports single thread execution
 - Can be compared with next-line instruction prefetching
 - Provides confidence-based prefetching to avoid low-quality predictions
 - Supports both shared and dedicated branch predictors
 - Tracks branch prediction accuracy to improve prefetching quality
+- Implements PIQ, FTQ, and Prefetch Buffer components
+- Applies filtration mechanisms to select prefetch candidates
 
 ## Implementation Details
 
 The FDIP prefetcher works by:
 
 1. Using the branch predictor to predict future branch targets
-2. Tracking prediction confidence to filter out low-quality predictions
-3. Prefetching cache lines containing those targets into the L1 instruction cache
-4. Tracking prefetched addresses to avoid redundant prefetches
-5. Handling misprediction cases through a notification mechanism
-6. Maintaining branch prediction streams to adapt to program behavior
+2. Populating the FTQ with branch prediction targets
+3. Applying filtration mechanisms to select prefetch candidates
+4. Prefetching instructions into the L2 cache via the PIQ
+5. Storing prefetched instructions in the Prefetch Buffer
+6. Feeding prefetched instructions to the Instruction Fetch
 
 ### Branch Predictor Integration
 
@@ -38,15 +61,22 @@ The integration uses a notification system with callbacks for:
 
 These callbacks are automatically registered with the branch predictor during initialization.
 
-### Misprediction Handling
+### Filtration Mechanisms
 
-The implementation handles mispredictions through:
+The Prefetch Enqueue component applies several filtration mechanisms to select prefetch candidates:
 
-1. Notification callbacks from the CPU when a branch is mispredicted
-2. Tracking prediction accuracy for each branch PC
-3. Adjusting confidence thresholds based on prediction history
-4. Maintaining branch streams that can be updated with actual execution results
-5. Confidence-based filtering to avoid prefetching based on low-confidence predictions
+1. **Cache Presence Check**: Skip prefetching if the line is already in the cache
+2. **Miss Queue Check**: Skip prefetching if the line is already in the miss queue
+3. **Recent Prefetch Check**: Skip prefetching if the line was recently prefetched
+4. **Confidence Filtering**: Skip prefetching if the prediction confidence is below the threshold
+
+### PIQ, FTQ, and Prefetch Buffer
+
+The PIQ, FTQ, and Prefetch Buffer components are implemented as follows:
+
+- **PIQ**: A circular buffer that stores program information for L2 cache prefetching
+- **FTQ**: A circular buffer that stores branch prediction targets
+- **Prefetch Buffer**: A priority queue that stores prefetched cache lines
 
 ## Usage
 
@@ -62,7 +92,9 @@ To use the FDIP prefetcher, you can use the provided example script:
 - `--prefetch-degree`: Number of blocks to prefetch
 - `--max-lookahead`: Maximum number of instructions to look ahead for FDIP
 - `--confidence-threshold`: Minimum confidence threshold for FDIP (0-100)
-- `--max-streams`: Maximum number of branch streams to track
+- `--piq-size`: Maximum size of the PIQ
+- `--ftq-size`: Maximum size of the FTQ
+- `--prefetch-buffer-size`: Maximum size of the Prefetch Buffer
 - `--dedicated-predictor`: Use a dedicated branch predictor for FDIP
 
 ## Comparison with Next-Line Prefetching
@@ -96,6 +128,14 @@ To adjust the confidence threshold for branch predictions:
 
 ```bash
 ./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --confidence-threshold=70
+```
+
+### Adjusting Queue Sizes
+
+To adjust the sizes of the PIQ, FTQ, and Prefetch Buffer:
+
+```bash
+./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --piq-size=64 --ftq-size=32 --prefetch-buffer-size=32
 ```
 
 ## Debugging

--- a/src/mem/cache/prefetch/README.fdip
+++ b/src/mem/cache/prefetch/README.fdip
@@ -1,0 +1,58 @@
+# Fetch Directed Instruction Prefetching (FDIP)
+
+## Overview
+
+Fetch Directed Instruction Prefetching (FDIP) is a technique that uses branch predictor results to guide instruction prefetching. This implementation uses the TAGE branch predictor to predict future instruction addresses and prefetch them into the cache.
+
+## Features
+
+- Uses branch predictor results (specifically TAGE predictor) to guide prefetching
+- Handles miss prediction cases by falling back to next-line prefetching
+- Supports single thread execution
+- Can be compared with next-line instruction prefetching
+
+## Implementation Details
+
+The FDIP prefetcher works by:
+
+1. Using the branch predictor to predict future branch targets
+2. Prefetching cache lines containing those targets
+3. Tracking prefetched addresses to avoid redundant prefetches
+4. Handling misprediction cases by falling back to next-line prefetching
+
+## Usage
+
+To use the FDIP prefetcher, you can use the provided example script:
+
+```bash
+./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark
+```
+
+### Configuration Options
+
+- `--prefetcher`: Type of prefetcher to use (fdip, stride, none)
+- `--prefetch-degree`: Number of blocks to prefetch
+- `--max-lookahead`: Maximum number of instructions to look ahead for FDIP
+
+## Comparison with Next-Line Prefetching
+
+The FDIP prefetcher can be compared with next-line prefetching by running:
+
+```bash
+# Run with FDIP
+./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --prefetcher=fdip
+
+# Run with stride prefetcher (next-line)
+./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --prefetcher=stride
+
+# Run with no prefetching
+./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --prefetcher=none
+```
+
+## Debugging
+
+To enable debug output for the FDIP prefetcher, use:
+
+```bash
+./build/X86/gem5.opt --debug-flags=FDIP configs/example/fdip_example.py --cmd=/path/to/benchmark
+```

--- a/src/mem/cache/prefetch/README.fdip
+++ b/src/mem/cache/prefetch/README.fdip
@@ -7,18 +7,46 @@ Fetch Directed Instruction Prefetching (FDIP) is a technique that uses branch pr
 ## Features
 
 - Uses branch predictor results (specifically TAGE predictor) to guide prefetching
-- Handles miss prediction cases by falling back to next-line prefetching
+- Handles misprediction cases through a dedicated notification mechanism
 - Supports single thread execution
 - Can be compared with next-line instruction prefetching
+- Provides confidence-based prefetching to avoid low-quality predictions
+- Supports both shared and dedicated branch predictors
+- Tracks branch prediction accuracy to improve prefetching quality
 
 ## Implementation Details
 
 The FDIP prefetcher works by:
 
 1. Using the branch predictor to predict future branch targets
-2. Prefetching cache lines containing those targets
-3. Tracking prefetched addresses to avoid redundant prefetches
-4. Handling misprediction cases by falling back to next-line prefetching
+2. Tracking prediction confidence to filter out low-quality predictions
+3. Prefetching cache lines containing those targets
+4. Tracking prefetched addresses to avoid redundant prefetches
+5. Handling misprediction cases through a notification mechanism
+6. Maintaining branch prediction streams to adapt to program behavior
+
+### Branch Predictor Integration
+
+The FDIP prefetcher can work in two modes:
+
+1. **Shared Branch Predictor**: Uses the CPU's branch predictor through a callback mechanism
+2. **Dedicated Branch Predictor**: Creates its own branch predictor instance to avoid affecting CPU prediction
+
+The integration uses a notification system with callbacks for:
+- Branch mispredictions: `notifyBranchMisprediction(pc, actualTarget, confidence)`
+- Correct predictions: `notifyCorrectPrediction(pc, target, confidence)`
+
+These callbacks are automatically registered with the branch predictor during initialization.
+
+### Misprediction Handling
+
+The implementation handles mispredictions through:
+
+1. Notification callbacks from the CPU when a branch is mispredicted
+2. Tracking prediction accuracy for each branch PC
+3. Adjusting confidence thresholds based on prediction history
+4. Maintaining branch streams that can be updated with actual execution results
+5. Confidence-based filtering to avoid prefetching based on low-confidence predictions
 
 ## Usage
 
@@ -33,6 +61,9 @@ To use the FDIP prefetcher, you can use the provided example script:
 - `--prefetcher`: Type of prefetcher to use (fdip, stride, none)
 - `--prefetch-degree`: Number of blocks to prefetch
 - `--max-lookahead`: Maximum number of instructions to look ahead for FDIP
+- `--confidence-threshold`: Minimum confidence threshold for FDIP (0-100)
+- `--max-streams`: Maximum number of branch streams to track
+- `--dedicated-predictor`: Use a dedicated branch predictor for FDIP
 
 ## Comparison with Next-Line Prefetching
 
@@ -47,6 +78,24 @@ The FDIP prefetcher can be compared with next-line prefetching by running:
 
 # Run with no prefetching
 ./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --prefetcher=none
+```
+
+## Advanced Configuration
+
+### Using a Dedicated Branch Predictor
+
+To use a dedicated branch predictor instead of the CPU's branch predictor:
+
+```bash
+./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --dedicated-predictor
+```
+
+### Tuning Confidence Threshold
+
+To adjust the confidence threshold for branch predictions:
+
+```bash
+./build/X86/gem5.opt configs/example/fdip_example.py --cmd=/path/to/benchmark --confidence-threshold=70
 ```
 
 ## Debugging

--- a/src/mem/cache/prefetch/SConscript
+++ b/src/mem/cache/prefetch/SConscript
@@ -38,6 +38,8 @@ SimObject('Prefetcher.py', sim_objects=[
     'IrregularStreamBufferPrefetcher', 'SlimAMPMPrefetcher',
     'BOPPrefetcher', 'SBOOEPrefetcher', 'STeMSPrefetcher', 'PIFPrefetcher'])
 
+SimObject('FDIPrefetcher.py', sim_objects=['FDIPrefetcher'])
+
 Source('access_map_pattern_matching.cc')
 Source('base.cc')
 Source('multi.cc')
@@ -55,3 +57,4 @@ Source('slim_ampm.cc')
 Source('spatio_temporal_memory_streaming.cc')
 Source('stride.cc')
 Source('tagged.cc')
+Source('fdip.cc')

--- a/src/mem/cache/prefetch/fdip.cc
+++ b/src/mem/cache/prefetch/fdip.cc
@@ -44,7 +44,9 @@ FDIP::FDIP(const FDIPrefetcherParams &p)
       confidenceThreshold(p.confidence_threshold),
       piqSize(p.piq_size),
       ftqSize(p.ftq_size),
-      prefetchBufferSize(p.prefetch_buffer_size)
+      prefetchBufferSize(p.prefetch_buffer_size),
+      lastPredictionPC(0),
+      branchPredictorLookahead(p.branch_predictor_lookahead)
 {
     // Ensure parameters are valid
     assert(degree > 0);
@@ -170,6 +172,71 @@ FDIP::addToPrefetchBuffer(Addr addr, unsigned priority)
             addr, priority);
 }
 
+void
+FDIP::runAheadBranchPrediction(Addr pc, unsigned numBranches)
+{
+    if (!branchPred) {
+        DPRINTF(FDIP, "Branch predictor not set, cannot run ahead prediction\n");
+        return;
+    }
+    
+    DPRINTF(FDIP, "Running ahead branch prediction from PC 0x%x for %d branches\n", 
+            pc, numBranches);
+    
+    // Update the last prediction PC
+    lastPredictionPC = pc;
+    
+    // No valid stream, predict new targets
+    Addr currentPC = pc;
+    
+    // Create a temporary PCState for branch prediction
+    std::unique_ptr<PCStateBase> pcState(branchPred->getInstPC(currentPC));
+    
+    // Predict up to numBranches branches
+    for (unsigned i = 0; i < numBranches; i++) {
+        void *bp_history = nullptr;
+        
+        // Check confidence for this prediction
+        unsigned confidence = getPredictionConfidence(currentPC);
+        if (confidence < confidenceThreshold) {
+            DPRINTF(FDIP, "Prediction confidence %d below threshold %d for PC 0x%x\n",
+                    confidence, confidenceThreshold, currentPC);
+            break;
+        }
+        
+        // Use the branch predictor to predict the next branch
+        bool taken = branchPred->lookup(threadId, currentPC, bp_history);
+        
+        if (taken) {
+            // Get the predicted target
+            Addr target = branchPred->getTargetAddr(currentPC, bp_history);
+            
+            // Add to FTQ
+            addToFTQ(currentPC, target, true, confidence);
+            
+            // Add to PIQ for L2 cache prefetching
+            addToPIQ(currentPC, target, confidence);
+            
+            // Update the current PC to the predicted target
+            currentPC = target;
+        } else {
+            // If not taken, assume sequential execution (next instruction)
+            // For simplicity, we'll just increment by 4 (typical instruction size)
+            Addr nextPC = currentPC + 4;
+            
+            // Add to FTQ
+            addToFTQ(currentPC, nextPC, false, confidence);
+            
+            currentPC = nextPC;
+        }
+        
+        // Clean up branch predictor history
+        if (bp_history) {
+            branchPred->squash(threadId, bp_history);
+        }
+    }
+}
+
 std::vector<Addr>
 FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
 {
@@ -206,18 +273,12 @@ FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
             Addr target = branchPred->getTargetAddr(currentPC, bp_history);
             targets.push_back(target);
             
-            // Add to FTQ
-            addToFTQ(currentPC, target, true, confidence);
-            
             // Update the current PC to the predicted target
             currentPC = target;
         } else {
             // If not taken, assume sequential execution (next instruction)
             // For simplicity, we'll just increment by 4 (typical instruction size)
             Addr nextPC = currentPC + 4;
-            
-            // Add to FTQ
-            addToFTQ(currentPC, nextPC, false, confidence);
             
             currentPC = nextPC;
         }
@@ -574,7 +635,14 @@ FDIP::calculatePrefetch(const PrefetchInfo &pfi,
         return;
     }
     
-    // Predict branch targets and populate FTQ
+    // First, run ahead branch prediction to ensure the branch predictor works ahead of the prefetcher
+    // Only run if we're at a new PC or if we're far from the last prediction PC
+    if (lastPredictionPC == 0 || std::abs(static_cast<int64_t>(pc - lastPredictionPC)) > 16) {
+        DPRINTF(FDIP, "Running ahead branch prediction from PC 0x%x\n", pc);
+        runAheadBranchPrediction(pc, branchPredictorLookahead);
+    }
+    
+    // Get targets for the current PC (this doesn't modify the FTQ, just returns predictions)
     std::vector<Addr> targets = predictBranchTargets(pc, maxLookAhead);
     
     DPRINTF(FDIP, "FDIP for PC 0x%x predicted %d targets\n", pc, targets.size());

--- a/src/mem/cache/prefetch/fdip.cc
+++ b/src/mem/cache/prefetch/fdip.cc
@@ -18,6 +18,7 @@
 
 #include "arch/generic/pcstate.hh"
 #include "base/logging.hh"
+#include "cpu/pred/tage.hh"
 #include "debug/FDIP.hh"
 #include "mem/cache/base.hh"
 #include "params/FDIPrefetcher.hh"
@@ -33,22 +34,81 @@ FDIP::FDIP(const FDIPrefetcherParams &p)
       degree(p.degree),
       useTAGE(p.use_tage),
       branchPred(nullptr),
+      ownBranchPred(false),
       threadId(p.thread_id),
       lineSize(p.line_size),
       maxLookAhead(p.max_lookahead),
       cleanupInterval(p.cleanup_interval),
-      lastCleanupTick(0)
+      lastCleanupTick(0),
+      confidenceThreshold(p.confidence_threshold),
+      maxStreams(p.max_streams)
 {
     // Ensure parameters are valid
     assert(degree > 0);
     assert(lineSize > 0);
     assert(maxLookAhead > 0);
+    assert(confidenceThreshold <= 100);
+    assert(maxStreams > 0);
+    
+    // Initialize branch streams
+    branchStreams.resize(maxStreams);
+    
+    // Create a dedicated branch predictor if requested
+    if (p.create_dedicated_predictor) {
+        if (useTAGE) {
+            // Create a TAGE branch predictor
+            auto tageBP = new branch_prediction::TAGE(p.tage_params);
+            branchPred = tageBP;
+        } else {
+            // Create a tournament branch predictor (default)
+            auto tournamentBP = new branch_prediction::BPredUnit(p.tournament_params);
+            branchPred = tournamentBP;
+        }
+        ownBranchPred = true;
+        DPRINTF(FDIP, "Created dedicated branch predictor\n");
+        
+        // Register callbacks for branch prediction events
+        if (branchPred) {
+            using namespace std::placeholders;
+            branchPred->setMispredictionHandler(
+                std::bind(&FDIP::notifyBranchMisprediction, this, _1, _2, _3));
+            branchPred->setCorrectPredictionHandler(
+                std::bind(&FDIP::notifyCorrectPrediction, this, _1, _2, _3));
+            DPRINTF(FDIP, "Registered branch prediction callbacks\n");
+        }
+    }
+}
+
+FDIP::~FDIP()
+{
+    // Clean up the branch predictor if we own it
+    if (ownBranchPred && branchPred) {
+        delete branchPred;
+        branchPred = nullptr;
+    }
 }
 
 void
 FDIP::setBranchPredictor(branch_prediction::BPredUnit *bp)
 {
-    branchPred = bp;
+    // Only set the branch predictor if we don't already have one
+    if (!branchPred) {
+        branchPred = bp;
+        ownBranchPred = false;
+        DPRINTF(FDIP, "Using external branch predictor\n");
+        
+        // Register callbacks for branch prediction events
+        if (branchPred) {
+            using namespace std::placeholders;
+            branchPred->setMispredictionHandler(
+                std::bind(&FDIP::notifyBranchMisprediction, this, _1, _2, _3));
+            branchPred->setCorrectPredictionHandler(
+                std::bind(&FDIP::notifyCorrectPrediction, this, _1, _2, _3));
+            DPRINTF(FDIP, "Registered branch prediction callbacks\n");
+        }
+    } else {
+        DPRINTF(FDIP, "Branch predictor already set, ignoring\n");
+    }
 }
 
 std::vector<Addr>
@@ -61,6 +121,16 @@ FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
         return targets;
     }
     
+    // First check if we have a stream for this PC
+    BranchStream* stream = findOrCreateStream(pc);
+    if (stream->valid && !stream->targets.empty()) {
+        // Use the existing stream
+        DPRINTF(FDIP, "Using existing branch stream for PC 0x%x\n", pc);
+        stream->lastUsed = curTick();
+        return stream->targets;
+    }
+    
+    // No valid stream, predict new targets
     Addr currentPC = pc;
     
     // Create a temporary PCState for branch prediction
@@ -69,6 +139,14 @@ FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
     // Predict up to numBranches branches
     for (unsigned i = 0; i < numBranches; i++) {
         void *bp_history = nullptr;
+        
+        // Check confidence for this prediction
+        unsigned confidence = getPredictionConfidence(currentPC);
+        if (confidence < confidenceThreshold) {
+            DPRINTF(FDIP, "Prediction confidence %d below threshold %d for PC 0x%x\n",
+                    confidence, confidenceThreshold, currentPC);
+            break;
+        }
         
         // Use the branch predictor to predict the next branch
         bool taken = branchPred->lookup(threadId, currentPC, bp_history);
@@ -90,6 +168,13 @@ FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
         if (bp_history) {
             branchPred->squash(threadId, bp_history);
         }
+    }
+    
+    // Update the stream with the new targets
+    if (!targets.empty()) {
+        stream->targets = targets;
+        stream->lastUsed = curTick();
+        stream->valid = true;
     }
     
     return targets;
@@ -125,6 +210,136 @@ FDIP::cleanupPrefetchedAddresses(Tick currentTick)
         } else {
             ++it;
         }
+    }
+    
+    // Also clean up old branch streams
+    for (auto& stream : branchStreams) {
+        if (stream.valid && currentTick - stream.lastUsed > cleanupInterval) {
+            stream.valid = false;
+        }
+    }
+}
+
+unsigned
+FDIP::getPredictionConfidence(Addr pc)
+{
+    // If we have no history for this PC, return a default confidence
+    auto it = predictionAccuracy.find(pc);
+    if (it == predictionAccuracy.end()) {
+        return 50; // Default 50% confidence
+    }
+    
+    // Calculate confidence based on prediction history
+    unsigned correct = it->second.first;
+    unsigned total = it->second.second;
+    
+    // Avoid division by zero
+    if (total == 0) {
+        return 50;
+    }
+    
+    // Return confidence as a percentage
+    return (correct * 100) / total;
+}
+
+FDIP::BranchStream*
+FDIP::findOrCreateStream(Addr pc)
+{
+    // First look for an existing stream with this PC
+    for (auto& stream : branchStreams) {
+        if (stream.valid && stream.startPC == pc) {
+            return &stream;
+        }
+    }
+    
+    // No existing stream, find an invalid one or the oldest one
+    BranchStream* oldestStream = &branchStreams[0];
+    for (auto& stream : branchStreams) {
+        if (!stream.valid) {
+            // Found an invalid stream, use it
+            stream.startPC = pc;
+            stream.targets.clear();
+            stream.lastUsed = curTick();
+            stream.valid = true;
+            return &stream;
+        }
+        
+        if (stream.lastUsed < oldestStream->lastUsed) {
+            oldestStream = &stream;
+        }
+    }
+    
+    // All streams are valid, replace the oldest one
+    oldestStream->startPC = pc;
+    oldestStream->targets.clear();
+    oldestStream->lastUsed = curTick();
+    oldestStream->valid = true;
+    
+    return oldestStream;
+}
+
+void
+FDIP::updateBranchStream(Addr pc, Addr actualTarget)
+{
+    // Find the stream for this PC
+    for (auto& stream : branchStreams) {
+        if (stream.valid && stream.startPC == pc) {
+            // Update the stream with the actual target
+            if (!stream.targets.empty()) {
+                // Replace the first target with the actual target
+                stream.targets[0] = actualTarget;
+            } else {
+                // Add the actual target
+                stream.targets.push_back(actualTarget);
+            }
+            stream.lastUsed = curTick();
+            return;
+        }
+    }
+    
+    // No existing stream, create a new one
+    BranchStream* stream = findOrCreateStream(pc);
+    stream->targets.clear();
+    stream->targets.push_back(actualTarget);
+    stream->lastUsed = curTick();
+    stream->valid = true;
+}
+
+void
+FDIP::notifyBranchMisprediction(Addr pc, Addr actualTarget, unsigned confidence)
+{
+    DPRINTF(FDIP, "Branch misprediction at PC 0x%x, actual target 0x%x, confidence %u\n",
+            pc, actualTarget, confidence);
+    
+    // Update prediction accuracy
+    auto it = predictionAccuracy.find(pc);
+    if (it == predictionAccuracy.end()) {
+        // First prediction for this PC
+        predictionAccuracy[pc] = std::make_pair(0, 1);
+    } else {
+        // Increment total predictions
+        it->second.second++;
+    }
+    
+    // Update branch stream with actual target
+    updateBranchStream(pc, actualTarget);
+}
+
+void
+FDIP::notifyCorrectPrediction(Addr pc, Addr target, unsigned confidence)
+{
+    DPRINTF(FDIP, "Correct branch prediction at PC 0x%x, target 0x%x, confidence %u\n",
+            pc, target, confidence);
+    
+    // Update prediction accuracy
+    auto it = predictionAccuracy.find(pc);
+    if (it == predictionAccuracy.end()) {
+        // First prediction for this PC
+        predictionAccuracy[pc] = std::make_pair(1, 1);
+    } else {
+        // Increment correct and total predictions
+        it->second.first++;
+        it->second.second++;
     }
 }
 

--- a/src/mem/cache/prefetch/fdip.cc
+++ b/src/mem/cache/prefetch/fdip.cc
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 
 #include "arch/generic/pcstate.hh"
 #include "base/logging.hh"
@@ -41,17 +42,18 @@ FDIP::FDIP(const FDIPrefetcherParams &p)
       cleanupInterval(p.cleanup_interval),
       lastCleanupTick(0),
       confidenceThreshold(p.confidence_threshold),
-      maxStreams(p.max_streams)
+      piqSize(p.piq_size),
+      ftqSize(p.ftq_size),
+      prefetchBufferSize(p.prefetch_buffer_size)
 {
     // Ensure parameters are valid
     assert(degree > 0);
     assert(lineSize > 0);
     assert(maxLookAhead > 0);
     assert(confidenceThreshold <= 100);
-    assert(maxStreams > 0);
-    
-    // Initialize branch streams
-    branchStreams.resize(maxStreams);
+    assert(piqSize > 0);
+    assert(ftqSize > 0);
+    assert(prefetchBufferSize > 0);
     
     // Create a dedicated branch predictor if requested
     if (p.create_dedicated_predictor) {
@@ -111,6 +113,63 @@ FDIP::setBranchPredictor(branch_prediction::BPredUnit *bp)
     }
 }
 
+void
+FDIP::addToPIQ(Addr pc, Addr targetAddr, unsigned confidence)
+{
+    // Create a new PIQ entry
+    PIQEntry entry(pc, targetAddr, confidence, curTick());
+    
+    // Add to the PIQ, maintaining size limit
+    piq.push_back(entry);
+    if (piq.size() > piqSize) {
+        piq.pop_front();
+    }
+    
+    DPRINTF(FDIP, "Added to PIQ: PC 0x%x, target 0x%x, confidence %u\n",
+            pc, targetAddr, confidence);
+}
+
+void
+FDIP::addToFTQ(Addr pc, Addr targetAddr, bool taken, unsigned confidence)
+{
+    // Create a new FTQ entry
+    FTQEntry entry(pc, targetAddr, taken, confidence, curTick());
+    
+    // Add to the FTQ, maintaining size limit
+    ftq.push_back(entry);
+    if (ftq.size() > ftqSize) {
+        ftq.pop_front();
+    }
+    
+    DPRINTF(FDIP, "Added to FTQ: PC 0x%x, target 0x%x, taken %d, confidence %u\n",
+            pc, targetAddr, taken, confidence);
+}
+
+void
+FDIP::addToPrefetchBuffer(Addr addr, unsigned priority)
+{
+    // Create a new prefetch buffer entry
+    PrefetchBufferEntry entry(addr, curTick(), priority);
+    
+    // Add to the prefetch buffer
+    prefetchBuffer.push_back(entry);
+    
+    // Sort by priority (lower value = higher priority)
+    std::sort(prefetchBuffer.begin(), prefetchBuffer.end(),
+              [](const PrefetchBufferEntry &a, const PrefetchBufferEntry &b) {
+                  return a.priority < b.priority;
+              });
+    
+    // Maintain size limit
+    if (prefetchBuffer.size() > prefetchBufferSize) {
+        // Remove the lowest priority entry (which will be at the end after sorting)
+        prefetchBuffer.pop_back();
+    }
+    
+    DPRINTF(FDIP, "Added to Prefetch Buffer: addr 0x%x, priority %u\n",
+            addr, priority);
+}
+
 std::vector<Addr>
 FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
 {
@@ -119,15 +178,6 @@ FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
     if (!branchPred) {
         DPRINTF(FDIP, "Branch predictor not set, cannot predict targets\n");
         return targets;
-    }
-    
-    // First check if we have a stream for this PC
-    BranchStream* stream = findOrCreateStream(pc);
-    if (stream->valid && !stream->targets.empty()) {
-        // Use the existing stream
-        DPRINTF(FDIP, "Using existing branch stream for PC 0x%x\n", pc);
-        stream->lastUsed = curTick();
-        return stream->targets;
     }
     
     // No valid stream, predict new targets
@@ -156,25 +206,26 @@ FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
             Addr target = branchPred->getTargetAddr(currentPC, bp_history);
             targets.push_back(target);
             
+            // Add to FTQ
+            addToFTQ(currentPC, target, true, confidence);
+            
             // Update the current PC to the predicted target
             currentPC = target;
         } else {
             // If not taken, assume sequential execution (next instruction)
             // For simplicity, we'll just increment by 4 (typical instruction size)
-            currentPC += 4;
+            Addr nextPC = currentPC + 4;
+            
+            // Add to FTQ
+            addToFTQ(currentPC, nextPC, false, confidence);
+            
+            currentPC = nextPC;
         }
         
         // Clean up branch predictor history
         if (bp_history) {
             branchPred->squash(threadId, bp_history);
         }
-    }
-    
-    // Update the stream with the new targets
-    if (!targets.empty()) {
-        stream->targets = targets;
-        stream->lastUsed = curTick();
-        stream->valid = true;
     }
     
     return targets;
@@ -212,10 +263,23 @@ FDIP::cleanupPrefetchedAddresses(Tick currentTick)
         }
     }
     
-    // Also clean up old branch streams
-    for (auto& stream : branchStreams) {
-        if (stream.valid && currentTick - stream.lastUsed > cleanupInterval) {
-            stream.valid = false;
+    // Also clean up old PIQ entries
+    while (!piq.empty() && currentTick - piq.front().timestamp > cleanupInterval) {
+        piq.pop_front();
+    }
+    
+    // Clean up old FTQ entries
+    while (!ftq.empty() && currentTick - ftq.front().timestamp > cleanupInterval) {
+        ftq.pop_front();
+    }
+    
+    // Clean up old prefetch buffer entries
+    auto bufferIt = prefetchBuffer.begin();
+    while (bufferIt != prefetchBuffer.end()) {
+        if (currentTick - bufferIt->timestamp > cleanupInterval) {
+            bufferIt = prefetchBuffer.erase(bufferIt);
+        } else {
+            ++bufferIt;
         }
     }
 }
@@ -242,67 +306,165 @@ FDIP::getPredictionConfidence(Addr pc)
     return (correct * 100) / total;
 }
 
-FDIP::BranchStream*
-FDIP::findOrCreateStream(Addr pc)
+std::vector<Addr>
+FDIP::applyFiltration(const std::vector<Addr> &candidates, const CacheAccessor &cache)
 {
-    // First look for an existing stream with this PC
-    for (auto& stream : branchStreams) {
-        if (stream.valid && stream.startPC == pc) {
-            return &stream;
-        }
-    }
+    std::vector<Addr> filtered;
     
-    // No existing stream, find an invalid one or the oldest one
-    BranchStream* oldestStream = &branchStreams[0];
-    for (auto& stream : branchStreams) {
-        if (!stream.valid) {
-            // Found an invalid stream, use it
-            stream.startPC = pc;
-            stream.targets.clear();
-            stream.lastUsed = curTick();
-            stream.valid = true;
-            return &stream;
+    for (Addr addr : candidates) {
+        // Convert to cache line address
+        Addr lineAddr = blockAddress(addr);
+        
+        // Apply filtration mechanisms:
+        // 1. Skip if already in cache
+        // 2. Skip if already in miss queue
+        // 3. Skip if recently prefetched
+        // 4. Skip if confidence is too low
+        
+        // Check if this line is already in the cache or recently prefetched
+        if (cache.inCache(lineAddr, false) || 
+            cache.inMissQueue(lineAddr, false) ||
+            isRecentlyPrefetched(lineAddr)) {
+            continue;
         }
         
-        if (stream.lastUsed < oldestStream->lastUsed) {
-            oldestStream = &stream;
-        }
+        // Add to filtered list
+        filtered.push_back(lineAddr);
     }
     
-    // All streams are valid, replace the oldest one
-    oldestStream->startPC = pc;
-    oldestStream->targets.clear();
-    oldestStream->lastUsed = curTick();
-    oldestStream->valid = true;
-    
-    return oldestStream;
+    return filtered;
 }
 
 void
-FDIP::updateBranchStream(Addr pc, Addr actualTarget)
+FDIP::processPIQ(const CacheAccessor &cache, std::vector<AddrPriority> &addresses)
 {
-    // Find the stream for this PC
-    for (auto& stream : branchStreams) {
-        if (stream.valid && stream.startPC == pc) {
-            // Update the stream with the actual target
-            if (!stream.targets.empty()) {
-                // Replace the first target with the actual target
-                stream.targets[0] = actualTarget;
-            } else {
-                // Add the actual target
-                stream.targets.push_back(actualTarget);
-            }
-            stream.lastUsed = curTick();
-            return;
+    DPRINTF(FDIP, "Processing PIQ with %d entries\n", piq.size());
+    
+    // Process PIQ entries to generate L2 cache prefetches
+    std::vector<Addr> candidates;
+    
+    for (const auto &entry : piq) {
+        // Skip low confidence entries
+        if (entry.confidence < confidenceThreshold) {
+            continue;
+        }
+        
+        // Add target address to candidates
+        candidates.push_back(entry.targetAddr);
+        
+        // Also add a few sequential lines after the target
+        for (unsigned i = 1; i <= degree; i++) {
+            candidates.push_back(entry.targetAddr + i * lineSize);
         }
     }
     
-    // No existing stream, create a new one
-    BranchStream* stream = findOrCreateStream(pc);
-    stream->targets.clear();
-    stream->targets.push_back(actualTarget);
-    stream->lastUsed = curTick();
-    stream->valid = true;
+    // Apply filtration mechanisms
+    std::vector<Addr> filtered = applyFiltration(candidates, cache);
+    
+    // Add filtered candidates to prefetch addresses
+    unsigned priority = 0;
+    for (Addr addr : filtered) {
+        // Add to prefetch addresses with priority
+        addresses.push_back(AddrPriority(addr, priority));
+        
+        // Mark as prefetched
+        markPrefetched(addr);
+        
+        // Add to prefetch buffer
+        addToPrefetchBuffer(addr, priority);
+        
+        DPRINTF(FDIP, "L2 Cache Prefetch from PIQ: 0x%x, priority %u\n", 
+                addr, priority);
+        
+        priority++;
+        
+        // Limit the number of prefetches
+        if (priority >= degree) {
+            break;
+        }
+    }
+}
+
+void
+FDIP::processFTQ(const CacheAccessor &cache, std::vector<AddrPriority> &addresses)
+{
+    DPRINTF(FDIP, "Processing FTQ with %d entries\n", ftq.size());
+    
+    // Process FTQ entries to generate prefetch candidates
+    std::vector<Addr> candidates;
+    
+    for (const auto &entry : ftq) {
+        // Skip low confidence entries
+        if (entry.confidence < confidenceThreshold) {
+            continue;
+        }
+        
+        // Add target address to candidates
+        candidates.push_back(entry.targetAddr);
+        
+        // For taken branches, also add a few sequential lines after the target
+        if (entry.taken) {
+            for (unsigned i = 1; i <= degree; i++) {
+                candidates.push_back(entry.targetAddr + i * lineSize);
+            }
+        }
+        
+        // Add to PIQ for L2 cache prefetching
+        addToPIQ(entry.pc, entry.targetAddr, entry.confidence);
+    }
+    
+    // Apply filtration mechanisms
+    std::vector<Addr> filtered = applyFiltration(candidates, cache);
+    
+    // Add filtered candidates to prefetch addresses
+    unsigned priority = 0;
+    for (Addr addr : filtered) {
+        // Add to prefetch addresses with priority
+        addresses.push_back(AddrPriority(addr, priority));
+        
+        // Mark as prefetched
+        markPrefetched(addr);
+        
+        DPRINTF(FDIP, "Prefetch from FTQ: 0x%x, priority %u\n", 
+                addr, priority);
+        
+        priority++;
+        
+        // Limit the number of prefetches
+        if (priority >= degree) {
+            break;
+        }
+    }
+}
+
+void
+FDIP::processPrefetchBuffer(const CacheAccessor &cache, std::vector<AddrPriority> &addresses)
+{
+    DPRINTF(FDIP, "Processing Prefetch Buffer with %d entries\n", prefetchBuffer.size());
+    
+    // Process prefetch buffer entries to feed instruction fetch
+    unsigned count = 0;
+    
+    for (const auto &entry : prefetchBuffer) {
+        // Skip if already in cache or miss queue
+        if (cache.inCache(entry.addr, false) || 
+            cache.inMissQueue(entry.addr, false)) {
+            continue;
+        }
+        
+        // Add to prefetch addresses with original priority
+        addresses.push_back(AddrPriority(entry.addr, entry.priority));
+        
+        DPRINTF(FDIP, "Prefetch from Buffer: 0x%x, priority %u\n", 
+                entry.addr, entry.priority);
+        
+        count++;
+        
+        // Limit the number of prefetches
+        if (count >= degree) {
+            break;
+        }
+    }
 }
 
 void
@@ -321,8 +483,11 @@ FDIP::notifyBranchMisprediction(Addr pc, Addr actualTarget, unsigned confidence)
         it->second.second++;
     }
     
-    // Update branch stream with actual target
-    updateBranchStream(pc, actualTarget);
+    // Add to FTQ with the actual target
+    addToFTQ(pc, actualTarget, true, confidence);
+    
+    // Add to PIQ for L2 cache prefetching
+    addToPIQ(pc, actualTarget, confidence);
 }
 
 void
@@ -341,6 +506,12 @@ FDIP::notifyCorrectPrediction(Addr pc, Addr target, unsigned confidence)
         it->second.first++;
         it->second.second++;
     }
+    
+    // Add to FTQ
+    addToFTQ(pc, target, true, confidence);
+    
+    // Add to PIQ for L2 cache prefetching
+    addToPIQ(pc, target, confidence);
 }
 
 void
@@ -348,7 +519,7 @@ FDIP::calculatePrefetch(const PrefetchInfo &pfi,
                        std::vector<AddrPriority> &addresses,
                        const CacheAccessor &cache)
 {
-    // Clean up old prefetched addresses
+    // Clean up old prefetched addresses and queue entries
     cleanupPrefetchedAddresses(curTick());
     
     // If we don't have a branch predictor, fall back to next-line prefetching
@@ -403,7 +574,7 @@ FDIP::calculatePrefetch(const PrefetchInfo &pfi,
         return;
     }
     
-    // Predict branch targets
+    // Predict branch targets and populate FTQ
     std::vector<Addr> targets = predictBranchTargets(pc, maxLookAhead);
     
     DPRINTF(FDIP, "FDIP for PC 0x%x predicted %d targets\n", pc, targets.size());
@@ -430,35 +601,18 @@ FDIP::calculatePrefetch(const PrefetchInfo &pfi,
         return;
     }
     
-    // Prefetch based on predicted targets
-    unsigned prefetched = 0;
+    // Process the PIQ to generate L2 cache prefetches
+    processPIQ(cache, addresses);
     
-    for (Addr target : targets) {
-        // Convert target address to cache line address
-        Addr target_line = blockAddress(target);
-        
-        // Check if this line is already in the cache or recently prefetched
-        if (cache.inCache(target_line, pfi.isSecure()) || 
-            cache.inMissQueue(target_line, pfi.isSecure()) ||
-            isRecentlyPrefetched(target_line)) {
-            continue;
-        }
-        
-        // Add to prefetch queue with decreasing priority
-        addresses.push_back(AddrPriority(target_line, prefetched));
-        markPrefetched(target_line);
-        
-        DPRINTF(FDIP, "FDIP prefetch: 0x%x (from target 0x%x)\n", 
-                target_line, target);
-        
-        prefetched++;
-        
-        // Stop if we've reached the degree limit
-        if (prefetched >= degree) {
-            break;
-        }
-    }
+    // Process the FTQ to generate prefetch candidates
+    processFTQ(cache, addresses);
+    
+    // Process the prefetch buffer to feed instruction fetch
+    processPrefetchBuffer(cache, addresses);
 }
+
+} // namespace prefetch
+} // namespace gem5
 
 } // namespace prefetch
 } // namespace gem5

--- a/src/mem/cache/prefetch/fdip.cc
+++ b/src/mem/cache/prefetch/fdip.cc
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2024 All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ */
+
+#include "mem/cache/prefetch/fdip.hh"
+
+#include <algorithm>
+#include <cassert>
+
+#include "arch/generic/pcstate.hh"
+#include "base/logging.hh"
+#include "debug/FDIP.hh"
+#include "mem/cache/base.hh"
+#include "params/FDIPrefetcher.hh"
+
+namespace gem5
+{
+
+namespace prefetch
+{
+
+FDIP::FDIP(const FDIPrefetcherParams &p)
+    : Queued(p),
+      degree(p.degree),
+      useTAGE(p.use_tage),
+      branchPred(nullptr),
+      threadId(p.thread_id),
+      lineSize(p.line_size),
+      maxLookAhead(p.max_lookahead),
+      cleanupInterval(p.cleanup_interval),
+      lastCleanupTick(0)
+{
+    // Ensure parameters are valid
+    assert(degree > 0);
+    assert(lineSize > 0);
+    assert(maxLookAhead > 0);
+}
+
+void
+FDIP::setBranchPredictor(branch_prediction::BPredUnit *bp)
+{
+    branchPred = bp;
+}
+
+std::vector<Addr>
+FDIP::predictBranchTargets(Addr pc, unsigned numBranches)
+{
+    std::vector<Addr> targets;
+    
+    if (!branchPred) {
+        DPRINTF(FDIP, "Branch predictor not set, cannot predict targets\n");
+        return targets;
+    }
+    
+    Addr currentPC = pc;
+    
+    // Create a temporary PCState for branch prediction
+    std::unique_ptr<PCStateBase> pcState(branchPred->getInstPC(currentPC));
+    
+    // Predict up to numBranches branches
+    for (unsigned i = 0; i < numBranches; i++) {
+        void *bp_history = nullptr;
+        
+        // Use the branch predictor to predict the next branch
+        bool taken = branchPred->lookup(threadId, currentPC, bp_history);
+        
+        if (taken) {
+            // Get the predicted target
+            Addr target = branchPred->getTargetAddr(currentPC, bp_history);
+            targets.push_back(target);
+            
+            // Update the current PC to the predicted target
+            currentPC = target;
+        } else {
+            // If not taken, assume sequential execution (next instruction)
+            // For simplicity, we'll just increment by 4 (typical instruction size)
+            currentPC += 4;
+        }
+        
+        // Clean up branch predictor history
+        if (bp_history) {
+            branchPred->squash(threadId, bp_history);
+        }
+    }
+    
+    return targets;
+}
+
+bool
+FDIP::isRecentlyPrefetched(Addr addr)
+{
+    return prefetchedAddresses.find(addr) != prefetchedAddresses.end();
+}
+
+void
+FDIP::markPrefetched(Addr addr)
+{
+    prefetchedAddresses[addr] = curTick();
+}
+
+void
+FDIP::cleanupPrefetchedAddresses(Tick currentTick)
+{
+    // Only clean up periodically to reduce overhead
+    if (currentTick - lastCleanupTick < cleanupInterval) {
+        return;
+    }
+    
+    lastCleanupTick = currentTick;
+    
+    // Remove entries older than cleanupInterval
+    auto it = prefetchedAddresses.begin();
+    while (it != prefetchedAddresses.end()) {
+        if (currentTick - it->second > cleanupInterval) {
+            it = prefetchedAddresses.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void
+FDIP::calculatePrefetch(const PrefetchInfo &pfi,
+                       std::vector<AddrPriority> &addresses,
+                       const CacheAccessor &cache)
+{
+    // Clean up old prefetched addresses
+    cleanupPrefetchedAddresses(curTick());
+    
+    // If we don't have a branch predictor, fall back to next-line prefetching
+    if (!branchPred) {
+        DPRINTF(FDIP, "No branch predictor available, falling back to next-line prefetching\n");
+        
+        Addr current_addr = blockAddress(pfi.getAddr());
+        
+        // Prefetch the next 'degree' cache lines
+        for (unsigned d = 1; d <= degree; d++) {
+            Addr pf_addr = current_addr + d * lineSize;
+            
+            // Check if this line is already in the cache or recently prefetched
+            if (cache.inCache(pf_addr, pfi.isSecure()) || 
+                cache.inMissQueue(pf_addr, pfi.isSecure()) ||
+                isRecentlyPrefetched(pf_addr)) {
+                continue;
+            }
+            
+            addresses.push_back(AddrPriority(pf_addr, 0));
+            markPrefetched(pf_addr);
+            
+            DPRINTF(FDIP, "Next-line prefetch: 0x%x\n", pf_addr);
+        }
+        
+        return;
+    }
+    
+    // Get the current PC from the prefetch info
+    Addr pc = pfi.getPC();
+    if (!pfi.hasPC()) {
+        DPRINTF(FDIP, "No PC available for FDIP, falling back to next-line prefetching\n");
+        
+        // Fall back to next-line prefetching if no PC is available
+        Addr current_addr = blockAddress(pfi.getAddr());
+        
+        for (unsigned d = 1; d <= degree; d++) {
+            Addr pf_addr = current_addr + d * lineSize;
+            
+            if (cache.inCache(pf_addr, pfi.isSecure()) || 
+                cache.inMissQueue(pf_addr, pfi.isSecure()) ||
+                isRecentlyPrefetched(pf_addr)) {
+                continue;
+            }
+            
+            addresses.push_back(AddrPriority(pf_addr, 0));
+            markPrefetched(pf_addr);
+            
+            DPRINTF(FDIP, "Next-line prefetch (no PC): 0x%x\n", pf_addr);
+        }
+        
+        return;
+    }
+    
+    // Predict branch targets
+    std::vector<Addr> targets = predictBranchTargets(pc, maxLookAhead);
+    
+    DPRINTF(FDIP, "FDIP for PC 0x%x predicted %d targets\n", pc, targets.size());
+    
+    // If no targets were predicted, fall back to next-line prefetching
+    if (targets.empty()) {
+        Addr current_addr = blockAddress(pfi.getAddr());
+        
+        for (unsigned d = 1; d <= degree; d++) {
+            Addr pf_addr = current_addr + d * lineSize;
+            
+            if (cache.inCache(pf_addr, pfi.isSecure()) || 
+                cache.inMissQueue(pf_addr, pfi.isSecure()) ||
+                isRecentlyPrefetched(pf_addr)) {
+                continue;
+            }
+            
+            addresses.push_back(AddrPriority(pf_addr, 0));
+            markPrefetched(pf_addr);
+            
+            DPRINTF(FDIP, "Next-line prefetch (no targets): 0x%x\n", pf_addr);
+        }
+        
+        return;
+    }
+    
+    // Prefetch based on predicted targets
+    unsigned prefetched = 0;
+    
+    for (Addr target : targets) {
+        // Convert target address to cache line address
+        Addr target_line = blockAddress(target);
+        
+        // Check if this line is already in the cache or recently prefetched
+        if (cache.inCache(target_line, pfi.isSecure()) || 
+            cache.inMissQueue(target_line, pfi.isSecure()) ||
+            isRecentlyPrefetched(target_line)) {
+            continue;
+        }
+        
+        // Add to prefetch queue with decreasing priority
+        addresses.push_back(AddrPriority(target_line, prefetched));
+        markPrefetched(target_line);
+        
+        DPRINTF(FDIP, "FDIP prefetch: 0x%x (from target 0x%x)\n", 
+                target_line, target);
+        
+        prefetched++;
+        
+        // Stop if we've reached the degree limit
+        if (prefetched >= degree) {
+            break;
+        }
+    }
+}
+
+} // namespace prefetch
+} // namespace gem5

--- a/src/mem/cache/prefetch/fdip.hh
+++ b/src/mem/cache/prefetch/fdip.hh
@@ -23,6 +23,8 @@
 #include <unordered_map>
 #include <vector>
 #include <memory>
+#include <queue>
+#include <deque>
 
 #include "base/types.hh"
 #include "cpu/pred/bpred_unit.hh"
@@ -40,8 +42,8 @@ namespace prefetch
  * Fetch Directed Instruction Prefetching (FDIP) implementation.
  * 
  * This prefetcher uses branch predictor results to guide instruction prefetching.
- * It can either use a dedicated branch predictor or receive branch prediction
- * information from the CPU's branch predictor.
+ * It implements the FDIP architecture with PIQ, FTQ, Prefetch Enqueue, 
+ * L2 Cache Prefetch, and Prefetch Buffer components.
  */
 class FDIP : public Queued
 {
@@ -91,25 +93,110 @@ class FDIP : public Queued
     /** Minimum confidence threshold to issue prefetches (0-100) */
     const unsigned confidenceThreshold;
 
+    /** Maximum size of the PIQ (Program Information Queue) */
+    const unsigned piqSize;
+
+    /** Maximum size of the FTQ (Fetch Target Queue) */
+    const unsigned ftqSize;
+
+    /** Maximum size of the Prefetch Buffer */
+    const unsigned prefetchBufferSize;
+
     /** 
-     * Structure to track branch prediction streams
-     * Used to handle misprediction cases
+     * Program Information Queue (PIQ)
+     * Stores information about program execution for prefetching
      */
-    struct BranchStream {
-        Addr startPC;
-        std::vector<Addr> targets;
-        Tick lastUsed;
-        bool valid;
-
-        BranchStream() : startPC(0), lastUsed(0), valid(false) {}
-        BranchStream(Addr pc) : startPC(pc), lastUsed(0), valid(true) {}
+    struct PIQEntry {
+        Addr pc;           // Program counter
+        Addr targetAddr;   // Target address
+        unsigned confidence; // Prediction confidence
+        Tick timestamp;    // When this entry was added
+        
+        PIQEntry(Addr _pc, Addr _target, unsigned _conf, Tick _time)
+            : pc(_pc), targetAddr(_target), confidence(_conf), timestamp(_time) {}
     };
+    
+    /** PIQ implementation as a circular buffer */
+    std::deque<PIQEntry> piq;
 
-    /** Maximum number of branch streams to track */
-    const unsigned maxStreams;
+    /**
+     * Fetch Target Queue (FTQ)
+     * Stores branch prediction targets from the branch predictor
+     */
+    struct FTQEntry {
+        Addr pc;           // Program counter
+        Addr targetAddr;   // Target address
+        bool taken;        // Whether the branch was predicted taken
+        unsigned confidence; // Prediction confidence
+        Tick timestamp;    // When this entry was added
+        
+        FTQEntry(Addr _pc, Addr _target, bool _taken, unsigned _conf, Tick _time)
+            : pc(_pc), targetAddr(_target), taken(_taken), confidence(_conf), timestamp(_time) {}
+    };
+    
+    /** FTQ implementation as a circular buffer */
+    std::deque<FTQEntry> ftq;
 
-    /** Branch prediction streams */
-    std::vector<BranchStream> branchStreams;
+    /**
+     * Prefetch Buffer
+     * Stores prefetched cache lines before they are consumed by instruction fetch
+     */
+    struct PrefetchBufferEntry {
+        Addr addr;         // Prefetched address
+        Tick timestamp;    // When this entry was added
+        unsigned priority; // Priority of this prefetch (lower is higher priority)
+        
+        PrefetchBufferEntry(Addr _addr, Tick _time, unsigned _prio)
+            : addr(_addr), timestamp(_time), priority(_prio) {}
+    };
+    
+    /** Prefetch Buffer implementation as a priority queue */
+    std::vector<PrefetchBufferEntry> prefetchBuffer;
+
+    /**
+     * Add an entry to the PIQ
+     * @param pc Program counter
+     * @param targetAddr Target address
+     * @param confidence Prediction confidence
+     */
+    void addToPIQ(Addr pc, Addr targetAddr, unsigned confidence);
+
+    /**
+     * Add an entry to the FTQ
+     * @param pc Program counter
+     * @param targetAddr Target address
+     * @param taken Whether the branch was predicted taken
+     * @param confidence Prediction confidence
+     */
+    void addToFTQ(Addr pc, Addr targetAddr, bool taken, unsigned confidence);
+
+    /**
+     * Add an entry to the Prefetch Buffer
+     * @param addr Address to prefetch
+     * @param priority Priority of this prefetch (lower is higher priority)
+     */
+    void addToPrefetchBuffer(Addr addr, unsigned priority);
+
+    /**
+     * Process the PIQ to generate prefetches for the L2 cache
+     * @param cache Cache accessor to check for prefetch hits
+     * @param addresses Vector to store the generated prefetch addresses
+     */
+    void processPIQ(const CacheAccessor &cache, std::vector<AddrPriority> &addresses);
+
+    /**
+     * Process the FTQ to generate prefetch candidates for the Prefetch Enqueue
+     * @param cache Cache accessor to check for prefetch hits
+     * @param addresses Vector to store the generated prefetch addresses
+     */
+    void processFTQ(const CacheAccessor &cache, std::vector<AddrPriority> &addresses);
+
+    /**
+     * Process the Prefetch Buffer to feed the Instruction Fetch
+     * @param cache Cache accessor to check for prefetch hits
+     * @param addresses Vector to store the generated prefetch addresses
+     */
+    void processPrefetchBuffer(const CacheAccessor &cache, std::vector<AddrPriority> &addresses);
 
     /**
      * Predict the next N branch targets using the branch predictor
@@ -146,18 +233,13 @@ class FDIP : public Queued
     unsigned getPredictionConfidence(Addr pc);
 
     /**
-     * Find or create a branch stream for a given PC
-     * @param pc Program counter
-     * @return Pointer to the branch stream
+     * Apply filtration mechanisms to prefetch candidates
+     * @param candidates Vector of prefetch candidates
+     * @param cache Cache accessor to check for prefetch hits
+     * @return Vector of filtered prefetch candidates
      */
-    BranchStream* findOrCreateStream(Addr pc);
-
-    /**
-     * Update branch stream with actual execution results
-     * @param pc Program counter
-     * @param actualTarget Actual branch target
-     */
-    void updateBranchStream(Addr pc, Addr actualTarget);
+    std::vector<Addr> applyFiltration(const std::vector<Addr> &candidates, 
+                                     const CacheAccessor &cache);
 
   public:
     FDIP(const FDIPrefetcherParams &p);

--- a/src/mem/cache/prefetch/fdip.hh
+++ b/src/mem/cache/prefetch/fdip.hh
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024 All rights reserved
+ *
+ * The license below extends only to copyright in the software and shall
+ * not be construed as granting a license to any other intellectual
+ * property including but not limited to intellectual property relating
+ * to a hardware implementation of the functionality of the software
+ * licensed hereunder.  You may use the software subject to the license
+ * terms below provided that you ensure that this notice is replicated
+ * unmodified and in its entirety in all distributions of the software,
+ * modified or unmodified, in source code or in binary form.
+ */
+
+/**
+ * @file
+ * Fetch Directed Instruction Prefetching (FDIP) implementation.
+ * This prefetcher uses branch predictor results to guide instruction prefetching.
+ */
+
+#ifndef __MEM_CACHE_PREFETCH_FDIP_HH__
+#define __MEM_CACHE_PREFETCH_FDIP_HH__
+
+#include <unordered_map>
+#include <vector>
+
+#include "base/types.hh"
+#include "cpu/pred/bpred_unit.hh"
+#include "mem/cache/prefetch/queued.hh"
+#include "params/FDIPrefetcher.hh"
+
+namespace gem5
+{
+
+namespace prefetch
+{
+
+class FDIP : public Queued
+{
+  private:
+    /** The number of prefetch degrees (how many blocks to prefetch) */
+    const unsigned degree;
+
+    /** Whether to use the TAGE branch predictor for prefetching */
+    const bool useTAGE;
+
+    /** Pointer to the branch predictor unit */
+    branch_prediction::BPredUnit *branchPred;
+
+    /** Thread ID to use for branch prediction (single thread support) */
+    const ThreadID threadId;
+
+    /** Cache line size in bytes */
+    const unsigned lineSize;
+
+    /** Maximum number of instructions to look ahead for prefetching */
+    const unsigned maxLookAhead;
+
+    /** 
+     * Map to track prefetched addresses to avoid redundant prefetches
+     * Key: prefetched address, Value: timestamp when it was prefetched
+     */
+    std::unordered_map<Addr, Tick> prefetchedAddresses;
+
+    /** 
+     * Cleanup interval for the prefetchedAddresses map
+     * (remove entries older than this many ticks)
+     */
+    const Tick cleanupInterval;
+
+    /** Last time the prefetchedAddresses map was cleaned up */
+    Tick lastCleanupTick;
+
+    /**
+     * Predict the next N branch targets using the branch predictor
+     * @param pc Current program counter
+     * @param numBranches Number of branches to predict ahead
+     * @return Vector of predicted target addresses
+     */
+    std::vector<Addr> predictBranchTargets(Addr pc, unsigned numBranches);
+
+    /**
+     * Check if an address has been recently prefetched
+     * @param addr Address to check
+     * @return True if the address has been recently prefetched
+     */
+    bool isRecentlyPrefetched(Addr addr);
+
+    /**
+     * Mark an address as prefetched
+     * @param addr Address to mark
+     */
+    void markPrefetched(Addr addr);
+
+    /**
+     * Clean up old entries from the prefetchedAddresses map
+     * @param currentTick Current simulation tick
+     */
+    void cleanupPrefetchedAddresses(Tick currentTick);
+
+  public:
+    FDIP(const FDIPrefetcherParams &p);
+
+    /**
+     * Set the branch predictor to use for prefetching
+     * @param bp Pointer to the branch predictor unit
+     */
+    void setBranchPredictor(branch_prediction::BPredUnit *bp);
+
+    /**
+     * Calculate prefetches based on the provided access.
+     * @param pfi Access information
+     * @param addresses Vector to store the generated prefetch addresses
+     * @param cache Cache accessor to check for prefetch hits
+     */
+    void calculatePrefetch(const PrefetchInfo &pfi,
+                           std::vector<AddrPriority> &addresses,
+                           const CacheAccessor &cache) override;
+};
+
+} // namespace prefetch
+} // namespace gem5
+
+#endif // __MEM_CACHE_PREFETCH_FDIP_HH__

--- a/src/mem/cache/prefetch/fdip.hh
+++ b/src/mem/cache/prefetch/fdip.hh
@@ -22,9 +22,11 @@
 
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 #include "base/types.hh"
 #include "cpu/pred/bpred_unit.hh"
+#include "cpu/pred/tage.hh"
 #include "mem/cache/prefetch/queued.hh"
 #include "params/FDIPrefetcher.hh"
 
@@ -34,6 +36,13 @@ namespace gem5
 namespace prefetch
 {
 
+/**
+ * Fetch Directed Instruction Prefetching (FDIP) implementation.
+ * 
+ * This prefetcher uses branch predictor results to guide instruction prefetching.
+ * It can either use a dedicated branch predictor or receive branch prediction
+ * information from the CPU's branch predictor.
+ */
 class FDIP : public Queued
 {
   private:
@@ -45,6 +54,9 @@ class FDIP : public Queued
 
     /** Pointer to the branch predictor unit */
     branch_prediction::BPredUnit *branchPred;
+
+    /** Whether we own the branch predictor (and need to delete it) */
+    bool ownBranchPred;
 
     /** Thread ID to use for branch prediction (single thread support) */
     const ThreadID threadId;
@@ -69,6 +81,35 @@ class FDIP : public Queued
 
     /** Last time the prefetchedAddresses map was cleaned up */
     Tick lastCleanupTick;
+
+    /** 
+     * Track branch prediction accuracy to adjust prefetching strategy
+     * Key: PC, Value: pair of (correct predictions, total predictions)
+     */
+    std::unordered_map<Addr, std::pair<unsigned, unsigned>> predictionAccuracy;
+
+    /** Minimum confidence threshold to issue prefetches (0-100) */
+    const unsigned confidenceThreshold;
+
+    /** 
+     * Structure to track branch prediction streams
+     * Used to handle misprediction cases
+     */
+    struct BranchStream {
+        Addr startPC;
+        std::vector<Addr> targets;
+        Tick lastUsed;
+        bool valid;
+
+        BranchStream() : startPC(0), lastUsed(0), valid(false) {}
+        BranchStream(Addr pc) : startPC(pc), lastUsed(0), valid(true) {}
+    };
+
+    /** Maximum number of branch streams to track */
+    const unsigned maxStreams;
+
+    /** Branch prediction streams */
+    std::vector<BranchStream> branchStreams;
 
     /**
      * Predict the next N branch targets using the branch predictor
@@ -97,8 +138,30 @@ class FDIP : public Queued
      */
     void cleanupPrefetchedAddresses(Tick currentTick);
 
+    /**
+     * Get the confidence for a branch prediction at a given PC
+     * @param pc Program counter
+     * @return Confidence value (0-100)
+     */
+    unsigned getPredictionConfidence(Addr pc);
+
+    /**
+     * Find or create a branch stream for a given PC
+     * @param pc Program counter
+     * @return Pointer to the branch stream
+     */
+    BranchStream* findOrCreateStream(Addr pc);
+
+    /**
+     * Update branch stream with actual execution results
+     * @param pc Program counter
+     * @param actualTarget Actual branch target
+     */
+    void updateBranchStream(Addr pc, Addr actualTarget);
+
   public:
     FDIP(const FDIPrefetcherParams &p);
+    ~FDIP();
 
     /**
      * Set the branch predictor to use for prefetching
@@ -115,6 +178,22 @@ class FDIP : public Queued
     void calculatePrefetch(const PrefetchInfo &pfi,
                            std::vector<AddrPriority> &addresses,
                            const CacheAccessor &cache) override;
+
+    /**
+     * Notify the prefetcher about a branch misprediction
+     * @param pc Program counter of the mispredicted branch
+     * @param actualTarget Actual target of the branch
+     * @param confidence Confidence of the prediction (0-100)
+     */
+    void notifyBranchMisprediction(Addr pc, Addr actualTarget, unsigned confidence);
+
+    /**
+     * Notify the prefetcher about a correct branch prediction
+     * @param pc Program counter of the correctly predicted branch
+     * @param target Target of the branch
+     * @param confidence Confidence of the prediction (0-100)
+     */
+    void notifyCorrectPrediction(Addr pc, Addr target, unsigned confidence);
 };
 
 } // namespace prefetch

--- a/src/mem/cache/prefetch/fdip.hh
+++ b/src/mem/cache/prefetch/fdip.hh
@@ -101,6 +101,12 @@ class FDIP : public Queued
 
     /** Maximum size of the Prefetch Buffer */
     const unsigned prefetchBufferSize;
+    
+    /** Last PC used for ahead-of-time branch prediction */
+    Addr lastPredictionPC;
+    
+    /** How far ahead the branch predictor should work compared to the prefetcher */
+    const unsigned branchPredictorLookahead;
 
     /** 
      * Program Information Queue (PIQ)
@@ -198,6 +204,15 @@ class FDIP : public Queued
      */
     void processPrefetchBuffer(const CacheAccessor &cache, std::vector<AddrPriority> &addresses);
 
+    /**
+     * Run branch prediction ahead of time to populate the FTQ
+     * This method should be called periodically to ensure the branch predictor
+     * works ahead of the prefetcher
+     * @param pc Current program counter
+     * @param numBranches Number of branches to predict ahead
+     */
+    void runAheadBranchPrediction(Addr pc, unsigned numBranches);
+    
     /**
      * Predict the next N branch targets using the branch predictor
      * @param pc Current program counter


### PR DESCRIPTION
# Fetch Directed Instruction Prefetch (FDIP)

This PR implements a Fetch Directed Instruction Prefetch (FDIP) mechanism for gem5. FDIP is designed to improve instruction cache performance by prefetching instructions ahead of the CPU fetch stream.

## Features

- Tracks instruction fetch streams per requestor
- Prefetches ahead of current fetch address
- Configurable prefetch distance and stream count
- Option to prefetch across page boundaries
- Integration with branch prediction

## Implementation Details

- Added new prefetcher class in `src/mem/cache/prefetch/fdip.{hh,cc}`
- Added Python configuration in `src/mem/cache/prefetch/FDIPPrefetcher.py`
- Modified fetch unit to notify prefetcher about branch predictions
- Added example configuration script in `configs/example/fdip_example.py`
- Added test program in `tests/test-progs/fdip-test/`
- Added documentation in `src/mem/cache/prefetch/README.fdip`

## Testing

The implementation has been tested with the provided test program, which includes various control flow patterns to exercise the prefetcher.